### PR TITLE
Cast stat.Bavail to uint64

### DIFF
--- a/agent/fileutil/fileutil_unix.go
+++ b/agent/fileutil/fileutil_unix.go
@@ -85,9 +85,9 @@ func GetDiskSpaceInfo() (diskSpaceInfo DiskSpaceInfo, err error) {
 
 	// return DiskSpaceInfo with calculated bytes
 	return DiskSpaceInfo{
-		AvailBytes: (int64)(stat.Bavail * bSize), // available space = # of available blocks * block size
-		FreeBytes:  (int64)(stat.Bfree * bSize),  // free space = # of free blocks * block size
-		TotalBytes: (int64)(stat.Blocks * bSize), // total space = # of total blocks * block size
+		AvailBytes: (int64)((uint64)(stat.Bavail) * bSize), // available space = # of available blocks * block size
+		FreeBytes:  (int64)(stat.Bfree * bSize),            // free space = # of free blocks * block size
+		TotalBytes: (int64)(stat.Blocks * bSize),           // total space = # of total blocks * block size
 	}, nil
 }
 


### PR DESCRIPTION
On Linux the struct statfs.f_bavail field is unsigned, but on FreeBSD
the field is an int64_t.
