### PR TITLE
Report ssm.PlatformTypeLinux on FreeBSD

### DIFF
--- a/agent/ssm/service.go
+++ b/agent/ssm/service.go
@@ -128,6 +128,8 @@ func (svc *sdkService) UpdateInstanceInformation(
 		params.PlatformType = aws.String(ssm.PlatformTypeWindows)
 	case "linux":
 		params.PlatformType = aws.String(ssm.PlatformTypeLinux)
+	case "freebsd":
+		params.PlatformType = aws.String(ssm.PlatformTypeLinux)
 	default:
 		return nil, fmt.Errorf("Cannot report platform type of unrecognized OS. %v", goOS)
 	}


### PR DESCRIPTION
Alas, the SSM Agent API does not yet recognize that FreeBSD exists,
but pretending to be Linux at least allows "Run Command" to work.
