### PR TITLE
Skip checkstyle script ifdef SKIP_CHECKSTYLE

### DIFF
--- a/makefile
+++ b/makefile
@@ -27,8 +27,10 @@ endif
 export GOPATH
 
 checkstyle::
+ifndef SKIP_CHECKSTYLE
 #   Run checkstyle script
 	$(BGO_SPACE)/Tools/src/checkstyle.sh
+endif
 
 coverage:: build-linux
 	$(BGO_SPACE)/Tools/src/coverage.sh github.com/aws/amazon-ssm-agent/agent/...


### PR DESCRIPTION
Running the checkstyle script requires a significant additional
toolchain beyond what is needed for building the SSM Agent; in
third-party packaging systems (e.g., FreeBSD) it may be preferable
to skip running this code (especially if building from a release
which has preusmably already had its stylishness verified).
