### PR TITLE
Add build-freebsd and install-freebsd targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -33,7 +33,7 @@ checkstyle::
 coverage:: build-linux
 	$(BGO_SPACE)/Tools/src/coverage.sh github.com/aws/amazon-ssm-agent/agent/...
 
-build:: build-linux build-windows build-linux-386 build-windows-386
+build:: build-linux build-freebsd build-windows build-linux-386 build-windows-386
 
 prepack:: prepack-linux prepack-linux-386 prepack-windows prepack-windows-386
 
@@ -79,6 +79,20 @@ build-linux: checkstyle copy-src pre-build
 	$(BGO_SPACE)/agent/agent.go $(BGO_SPACE)/agent/agent_unix.go $(BGO_SPACE)/agent/agent_parser.go
 	GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/bin/linux_amd64/updater -v \
 	$(BGO_SPACE)/agent/update/updater/updater.go $(BGO_SPACE)/agent/update/updater/updater_unix.go
+
+.PHONY: build-freebsd
+build-freebsd: checkstyle copy-src pre-build
+	@echo "Build for freebsd agent"
+	GOOS=freebsd GOARCH=amd64 go build -ldflags "-s -w" -o $(BGO_SPACE)/bin/freebsd_amd64/amazon-ssm-agent -v \
+	$(BGO_SPACE)/agent/agent.go $(BGO_SPACE)/agent/agent_unix.go $(BGO_SPACE)/agent/agent_parser.go
+
+.PHONY: install-freebsd
+install-freebsd:
+	@echo "Install for freebsd agent"
+	install -m 555 $(BGO_SPACE)/bin/freebsd_amd64/amazon-ssm-agent $(DESTDIR)$(PREFIX)/sbin/
+	mkdir -p $(DESTDIR)$(PREFIX)/etc/amazon/ssm
+	install -m 644 $(BGO_SPACE)/bin/amazon-ssm-agent.json.template $(DESTDIR)$(PREFIX)/etc/amazon/ssm
+	install -m 644 $(BGO_SPACE)/bin/seelog_unix.xml $(DESTDIR)$(PREFIX)/etc/amazon/ssm/seelog_unix.xml.template
 
 .PHONY: build-darwin
 build-darwin: checkstyle copy-src pre-build


### PR DESCRIPTION
We do not build or install the 'updater' binary, since it doesn't do
anything useful on FreeBSD.  Updating the SSM Agent using established
FreeBSD package-management tools is probably a better idea than having
specific agent-updating code anyway...
