### PR TITLE
Update amazon-ssm-agent target symlink vendor

### DIFF
--- a/vendor/src/github.com/aws/amazon-ssm-agent
+++ b/vendor/src/github.com/aws/amazon-ssm-agent
@@ -1,1 +1,1 @@
-/Users/chanjeon/SSM/src/Amazon-ssm-agent
+../../../../../amazon-ssm-agent


### PR DESCRIPTION
Update the symlink that was pointing to chanjeon home dir.