### PR TITLE
Log 'Unexpected 'TimeoutSeconds' value %v received' as INFO

### DIFF
--- a/agent/plugins/pluginutil/pluginutil.go
+++ b/agent/plugins/pluginutil/pluginutil.go
@@ -145,7 +145,7 @@ func ValidateExecutionTimeout(log log.T, input interface{}) int {
 		num = int(f)
 		log.Infof("Unexpected 'TimeoutSeconds' float value %v received. Applying 'TimeoutSeconds' as %v", f, num)
 	default:
-		log.Errorf("Unexpected 'TimeoutSeconds' value %v received. Setting 'TimeoutSeconds' to default value %v", input, defaultExecutionTimeoutInSeconds)
+		log.Infof("Unexpected 'TimeoutSeconds' value %v received. Setting 'TimeoutSeconds' to default value %v", input, defaultExecutionTimeoutInSeconds)
 	}
 
 	if num < minExecutionTimeoutInSeconds || num > maxExecutionTimeoutInSeconds {


### PR DESCRIPTION
Switch the `Unexpected 'TimeoutSeconds' value %v received` message to INFO level, to match the log level of the surrounding messages.

The other 2 log messages in the surrounding code are already INFO level logs, so it seems odd that that line is set to ERROR level. As a default's being set, this doesn't really seem like an error, and just causes lots of log entries in the error log, that make finding true errors harder to spot.