### PR TITLE
Adding preliminary support for macOS (darwin)

### DIFF
--- a/agent/ssm/service.go
+++ b/agent/ssm/service.go
@@ -260,7 +260,7 @@ func (svc *sdkService) UpdateInstanceInformation(
 	switch goOS {
 	case "windows":
 		params.PlatformType = aws.String(ssm.PlatformTypeWindows)
-	case "linux", "freebsd":
+	case "darwin", "linux", "freebsd":
 		params.PlatformType = aws.String(ssm.PlatformTypeLinux)
 	default:
 		return nil, fmt.Errorf("Cannot report platform type of unrecognized OS. %v", goOS)


### PR DESCRIPTION
The hostname binary is available in darwin, albeit with different flags.
See: https://www.freebsd.org/cgi/man.cgi?query=hostname&manpath=FreeBSD+4.2