### PR TITLE
Have ssm-cli return an exit code

### DIFF
--- a/agent/cli-main/cli-main.go
+++ b/agent/cli-main/cli-main.go
@@ -22,5 +22,5 @@ import (
 )
 
 func main() {
-	cli.RunCommand(os.Args, os.Stdout)
+	os.Exit(cli.RunCommand(os.Args, os.Stdout))
 }

--- a/agent/cli/cli.go
+++ b/agent/cli/cli.go
@@ -26,17 +26,17 @@ import (
 
 // TODO:MF: make errors more like ssm-cli: error: <arg type>: <error>?
 // RunCommand parses and executes a single command line
-func RunCommand(args []string, out io.Writer) {
+func RunCommand(args []string, out io.Writer) int {
 	uuid.SwitchFormat(uuid.CleanHyphen)
 	if len(args) < 2 {
 		displayUsage(out)
-		return
+		return 1
 	}
 	err, _, command, subcommands, parameters := parseCommand(args)
 	if err != nil {
 		displayUsage(out)
 		fmt.Fprintln(out, err.Error())
-		return
+		return 1
 	}
 	if cmd, exists := cliutil.CliCommands[command]; exists {
 		if cliutil.IsHelp(subcommands, parameters) {
@@ -46,6 +46,7 @@ func RunCommand(args []string, out io.Writer) {
 			if cmdErr != nil {
 				displayUsage(out)
 				fmt.Fprintln(out, cmdErr.Error())
+				return 1
 			} else {
 				fmt.Fprintln(out, result)
 			}
@@ -56,7 +57,9 @@ func RunCommand(args []string, out io.Writer) {
 		displayUsage(out)
 		fmt.Fprintf(out, "\nInvalid command %v.  The following commands are supported:\n\n", command)
 		displayValidCommands(out)
+		return 1
 	}
+	return 0
 }
 
 // parseCommand turns the command line arguments into a command name and a map of flag names and values

--- a/agent/cli/cli_test.go
+++ b/agent/cli/cli_test.go
@@ -24,6 +24,7 @@ import (
 func TestCliUsage(t *testing.T) {
 	var buffer bytes.Buffer
 	args := []string{"ssm-cli"}
-	RunCommand(args, &buffer)
+	res := RunCommand(args, &buffer)
 	assert.Contains(t, buffer.String(), "usage")
+	assert.Equal(t, 1, res)
 }


### PR DESCRIPTION
This change makes it so that the ssm-cli will return a non-zero exit code if an error is encountered or if arguments are invalid.  Closes issue #132.