### PR TITLE
Session Manager: Allow for an optional script to be executed by sh at…

### DIFF
--- a/agent/session/plugins/shell/shell_unix.go
+++ b/agent/session/plugins/shell/shell_unix.go
@@ -42,6 +42,9 @@ const (
 	homeEnvVariable       = "HOME=/home/" + appconfig.DefaultRunAsUserName
 )
 
+//If the file below pointed to by ENV exists, the new shell will execute it on startup.
+var envEnvVariable = "ENV=" + appconfig.DefaultProgramFolder + "amazon-ssm-agent-shell-init"
+
 var getUserAndGroupIdCall = func(log log.T) (uid int, gid int, err error) {
 	return getUserAndGroupId(log)
 }
@@ -57,6 +60,7 @@ func StartPty(log log.T, isSessionShell bool) (stdin *os.File, stdout *os.File, 
 	cmd.Env = append(os.Environ(),
 		termEnvVariable,
 		homeEnvVariable,
+		envEnvVariable,
 	)
 
 	// Get the uid and gid of the runas user.


### PR DESCRIPTION
Session Manager: Allow for an optional script to be executed by sh at session start

*Issue #, if available:*

*Description of changes:*
Allow for an optional, customer-created script (/etc/amazon/ssm/amazon-ssm-agent-shell-init) to be run at the beginning of Session Manager sessions on Unix platforms. Though it could be used for anything, in my case I need it for compliance (to display terms of use).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
