### PR TITLE
Update regex for tokenInfo to allow "." (dots)

### DIFF
--- a/agent/plugins/downloadcontent/gitresource/privategithub/privategithub.go
+++ b/agent/plugins/downloadcontent/gitresource/privategithub/privategithub.go
@@ -104,7 +104,7 @@ func validateTokenParameter(tokenInfo string) (valid bool, err error) {
 
 	// Regex to check the pattern of the secure parameter required.
 	// pattern must be equal to {{ ssm-secure:parameter-name }}
-	var ssmSecureStringPattern = regexp.MustCompile("{{\\s*(" + ssmSecurePrefix + "[\\w-/]+)\\s*}}")
+	var ssmSecureStringPattern = regexp.MustCompile("{{\\s*(" + ssmSecurePrefix + "[\\w-./]+)\\s*}}")
 	if ssmSecureStringPattern.Match([]byte(tokenInfo)) {
 		return true, nil
 	}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-ssm-agent/issues/180

*Description of changes:*
This will allow the token-parameter-name to contain "." to follow SSM parameter name constraints
https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-parameter-name-constraints.html 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
