### PR TITLE
If the region is passed in the command line then use it directly

### DIFF
--- a/agent/agent_parser.go
+++ b/agent/agent_parser.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/amazon-ssm-agent/agent/fingerprint"
 	logger "github.com/aws/amazon-ssm-agent/agent/log"
 	"github.com/aws/amazon-ssm-agent/agent/managedInstances/registration"
+	"github.com/aws/amazon-ssm-agent/agent/platform"
 	"github.com/aws/amazon-ssm-agent/agent/ssm/anonauth"
 )
 
@@ -92,6 +93,10 @@ func processRegistration(log logger.T) (exitCode int) {
 		}
 		flagUsage()
 		return 1
+	}
+
+	if region != "" {
+		_ = platform.SetRegion(region)
 	}
 
 	// check if previously registered


### PR DESCRIPTION
Right now amazon-ssm-agent hangs for 50 seconds during instance registration on non-EC2 instances (or inside Fargate containers), because the code calls platform.Region() that has 10 retries each with a 5 second timeout.

This change allows setting region directly if it's provided in the command line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
