### PR TITLE
Set service working directory to /

### DIFF
--- a/packaging/linux/amazon-ssm-agent.service
+++ b/packaging/linux/amazon-ssm-agent.service
@@ -4,7 +4,6 @@ After=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/usr/bin/
 ExecStart=/usr/bin/amazon-ssm-agent
 KillMode=process
 Restart=on-failure

--- a/packaging/ubuntu/amazon-ssm-agent.service
+++ b/packaging/ubuntu/amazon-ssm-agent.service
@@ -4,7 +4,6 @@ After=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/usr/bin/
 ExecStart=/usr/bin/amazon-ssm-agent
 KillMode=process
 Restart=on-failure


### PR DESCRIPTION
*Description of changes:*

On Linux distributions that do not use systemd, the working directory is
/, which is the default. On distributions that do, /usr/bin is used.
This results in users connection with session manager ending up in
/usr/bin by default which is different than most would expect.

Not specifying a working directory defaults to /, which matches
non-systemd environments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
