### PR TITLE
Fix logging statements that use format strings but wrong function call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 sudo: false
 go:
-  - 1.9.0
+  - 1.9.x
 script: make coverage

--- a/agent/log/logger.go
+++ b/agent/log/logger.go
@@ -28,7 +28,7 @@ func GetLogger(log T, seelogConfig string) (logger seelog.LoggerInterface) {
 
 	err = seelog.ReplaceLogger(logger)
 	if err != nil {
-		log.Debug("Error is %v", err.Error())
+		log.Debugf("Error is %v", err.Error())
 	}
 	return logger
 }

--- a/agent/plugins/configurecontainers/windowscontainerutil/windowscontainerutil.go
+++ b/agent/plugins/configurecontainers/windowscontainerutil/windowscontainerutil.go
@@ -183,7 +183,7 @@ func RunInstallCommands(log log.T, orchestrationDirectory string, out iohandler.
 		//uncompress docker zip
 		fileutil.Uncompress(log, downloadOutput.LocalFilePath, DOCKER_UNCOMPRESS_DIRECTORY)
 	}
-	log.Debug("Zip file downloaded to %v", downloadOutput.LocalFilePath)
+	log.Debugf("Zip file downloaded to %v", downloadOutput.LocalFilePath)
 
 	//Set this process's path environment variable to include Docker
 	if !strings.Contains(strings.ToLower(os.Getenv("path")), strings.ToLower(DOCKER_INSTALLED_DIRECTORY)) {

--- a/agent/proxyconfig/proxy_windows.go
+++ b/agent/proxyconfig/proxy_windows.go
@@ -195,7 +195,7 @@ func SetProxySettings(log log.T) {
 func GetDefaultProxySettings(log log.T) (p HttpDefaultProxyConfig, err error) {
 	winhttp, err := syscall.LoadLibrary("Winhttp.dll")
 	if err != nil {
-		log.Error("Failed to load Winhttp.dll library: %v", err.Error())
+		log.Errorf("Failed to load Winhttp.dll library: %v", err.Error())
 		return p, err
 	}
 
@@ -203,7 +203,7 @@ func GetDefaultProxySettings(log log.T) (p HttpDefaultProxyConfig, err error) {
 
 	getDefaultProxy, err := syscall.GetProcAddress(winhttp, "WinHttpGetDefaultProxyConfiguration")
 	if err != nil {
-		log.Error("Failed to get default machine WinHTTP proxy configuration: %v", err.Error())
+		log.Errorf("Failed to get default machine WinHTTP proxy configuration: %v", err.Error())
 		return p, err
 	}
 
@@ -211,7 +211,7 @@ func GetDefaultProxySettings(log log.T) (p HttpDefaultProxyConfig, err error) {
 
 	ret, _, err := syscall.Syscall(uintptr(getDefaultProxy), 1, uintptr(unsafe.Pointer(settings)), 0, 0)
 	if ret != 1 {
-		log.Error("Failed to get default machine WinHTTP proxy configuration: %v", err.Error())
+		log.Errorf("Failed to get default machine WinHTTP proxy configuration: %v", err.Error())
 		return p, err
 	} else {
 		log.Infof("Getting WinHTTP proxy default configuration: %v", err.Error())

--- a/agent/s3util/s3util.go
+++ b/agent/s3util/s3util.go
@@ -214,7 +214,7 @@ func getRegionFromS3URLWithExponentialBackoff(url string, httpProvider HttpProvi
 func getRegionFromS3URL(log log.T, url string, httpProvider HttpProvider) (region string, err error) {
 	resp, err := httpProvider.Head(url)
 	if err != nil || resp == nil {
-		log.Info("Error when query S3 using url %v, error details : %v", url, err)
+		log.Infof("Error when query S3 using url %v, error details : %v", url, err)
 		err = errors.New(fmt.Sprintf("Failed query S3 using url %v - %s", url, err))
 		return "", err
 	}
@@ -224,7 +224,7 @@ func getRegionFromS3URL(log log.T, url string, httpProvider HttpProvider) (regio
 		return "", err
 	} else if region = resp.Header.Get(s3ResponseRegionHeader); region != "" {
 		// Region is fetched correctly at this point
-		log.Info("Getting region information about bucket %v", region)
+		log.Infof("Getting region information about bucket %v", region)
 		return region, nil
 	}
 	err = errors.New(fmt.Sprintf("Failed to fetch region from the header - %s", err))

--- a/agent/session/controlchannel/controlchannel.go
+++ b/agent/session/controlchannel/controlchannel.go
@@ -74,7 +74,7 @@ func (controlChannel *ControlChannel) Initialize(context context.T,
 	controlChannel.Processor = processor
 	controlChannel.wsChannel = &communicator.WebSocketChannel{}
 
-	log.Debug("Initialized controlchannel for instance: %s", instanceId)
+	log.Debugf("Initialized controlchannel for instance: %s", instanceId)
 }
 
 // SetWebSocket populates webchannel object.

--- a/agent/session/datachannel/datachannel.go
+++ b/agent/session/datachannel/datachannel.go
@@ -608,7 +608,7 @@ func (dataChannel *DataChannel) dataChannelIncomingMessageHandler(log log.T, raw
 		dataChannel.handleStartPublicationMessage(log, *streamDataMessage)
 		return nil
 	default:
-		log.Warn("Invalid message type received: %s", streamDataMessage.MessageType)
+		log.Warnf("Invalid message type received: %s", streamDataMessage.MessageType)
 	}
 
 	return nil


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-ssm-agent/issues/242

*Description of changes:*
Found and adjusted logging calls that had format strings, but were using "bare" function calls, resulting in format strings in the output (eg `%v` and `%s` strings in the log output)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
