### PR TITLE
fix typo in release notes version

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,7 +4,7 @@ Latest
 - Bug fix for Inventory data provider to support special characters
 - Bug fix for SSM MDS service name
 
-2.3.722.0
+2.3.772.0
 ===============
 - Upgrade AWS SDK
 - Add logging for fingerprint generation 


### PR DESCRIPTION
The most recent version number in the release notes is incorrect which was confusing me until I worked it out.. here is the fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
