### PR TITLE
Add Wants=network-online.target to systemd service

### DIFF
--- a/packaging/linux/amazon-ssm-agent.service
+++ b/packaging/linux/amazon-ssm-agent.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=amazon-ssm-agent
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple

--- a/packaging/ubuntu/amazon-ssm-agent.service
+++ b/packaging/ubuntu/amazon-ssm-agent.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=amazon-ssm-agent
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To start a systemd service after the network is up, the service has to pull in network-online.target. Only ordering itself after the target is not sufficient.

See [Running Services After the Network is up](https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/) from the systemd documentation for more details.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
