### PR TITLE
Updated rpmbuild comment to set SHA256 for digest algo

### DIFF
--- a/Tools/src/create_rpm.sh
+++ b/Tools/src/create_rpm.sh
@@ -61,6 +61,6 @@ echo "Creating the rpm package $FOLDER"
 SPEC_FILE="${GO_SPACE}/packaging/linux/amazon-ssm-agent.spec"
 BUILD_ROOT="${GO_SPACE}/bin/$FOLDER/linux"
 
-rpmbuild -bb --target $TARGET --define "rpmversion `cat ${GO_SPACE}/VERSION`" --define "_topdir bin/$FOLDER/linux/rpmbuild" --buildroot ${BUILD_ROOT} ${SPEC_FILE}
+rpmbuild -bb --target $TARGET --define "rpmversion `cat ${GO_SPACE}/VERSION`" --define "_topdir bin/$FOLDER/linux/rpmbuild" --define "_source_filedigest_algorithm 8" --define "_binary_filedigest_algorithm 8" --buildroot ${BUILD_ROOT} ${SPEC_FILE}
 cp ${GO_SPACE}/bin/$FOLDER/linux/rpmbuild/RPMS/$TARGET/*.rpm ${GO_SPACE}/bin/$FOLDER/amazon-ssm-agent.rpm
 rm -rf ${GO_SPACE}/bin/$FOLDER/linux/rpmbuild/RPMS/$TARGET/*


### PR DESCRIPTION
*Description of changes:*

Adds the digest algorithm to be used for the RPM build to set it to SHA256.

Follows a similar merge request as https://github.com/aws/amazon-cloudwatch-agent/pull/128

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


----

Note, I am unable to build the project locally to validate that the changes actually worked, as the build just stops after `ok  	github.com/aws/amazon-ssm-agent/agent/session/plugins/interactivecommands	0.054s` with no further output:

```
$ podman run -it --rm --name ssm-agent-build-container -v `pwd`:/amazon-ssm-agent ssm-agent-build-image make build-release
rm -rf /amazon-ssm-agent/bin/prepacked
rm -rf build/* bin/ pkg/ vendor/bin/ vendor/pkg/ .cover/
find . -type f -name '*.log' -delete
rm -rf /amazon-ssm-agent/build/private/src/github.com/aws/amazon-ssm-agent
mkdir -p /amazon-ssm-agent/build/private/src/github.com/aws/amazon-ssm-agent
copying files to /amazon-ssm-agent/build/private/src/github.com/aws/amazon-ssm-agent
cp -p -r /amazon-ssm-agent/agent /amazon-ssm-agent/build/private/src/github.com/aws/amazon-ssm-agent
cp -p -r /amazon-ssm-agent/core /amazon-ssm-agent/build/private/src/github.com/aws/amazon-ssm-agent
cp -p -r /amazon-ssm-agent/common /amazon-ssm-agent/build/private/src/github.com/aws/amazon-ssm-agent
for file in /amazon-ssm-agent/Tools/src/*.sh; do chmod 755 $file; done
Build amazon-ssm-agent
GOPATH=/amazon-ssm-agent/build/private:/amazon-ssm-agent/vendor:/go
rm -rf /amazon-ssm-agent/build/bin/ /amazon-ssm-agent/vendor/bin/
mkdir -p /amazon-ssm-agent/bin/
cp -p /amazon-ssm-agent/Tools/src/PipelineRunTests.sh /amazon-ssm-agent/bin/
cp -p /amazon-ssm-agent/LICENSE /amazon-ssm-agent/bin/
cp -p /amazon-ssm-agent/NOTICE.md /amazon-ssm-agent/bin/
cp -p /amazon-ssm-agent/amazon-ssm-agent.json.template /amazon-ssm-agent/bin/amazon-ssm-agent.json.template
cp -p /amazon-ssm-agent/seelog_unix.xml /amazon-ssm-agent/bin/
cp -p /amazon-ssm-agent/seelog_windows.xml.template /amazon-ssm-agent/bin/
cp -p /amazon-ssm-agent/agent/integration-cli/integration-cli.json /amazon-ssm-agent/bin/
Regenerate version file during pre-release
go run /amazon-ssm-agent/agent/version/versiongenerator/version-gen.go
Agent Version: 3.0.0.0cp -p /amazon-ssm-agent/VERSION /amazon-ssm-agent/bin/
SSM Agent release build
rm -rf /amazon-ssm-agent/vendor/pkg
# if you want to restrict to some specific package, sample below
# go test -v -gcflags "-N -l" -timeout 20m -tags=integration github.com/aws/amazon-ssm-agent/agent/fileutil/...
go test -gcflags "-N -l" -timeout 20m -tags=integration github.com/aws/amazon-ssm-agent/agent/...
# github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/application
build/private/src/github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/application/dataProvider.go:10:2: imported and not used: "github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/localpackages"
FAIL	github.com/aws/amazon-ssm-agent/agent/agent [build failed]
ok  	github.com/aws/amazon-ssm-agent/agent/agentlogstocloudwatch/cloudwatchlogspublisher	5.075s
ok  	github.com/aws/amazon-ssm-agent/agent/agentlogstocloudwatch/cloudwatchlogsqueue	0.070s
ok  	github.com/aws/amazon-ssm-agent/agent/appconfig	0.007s
ok  	github.com/aws/amazon-ssm-agent/agent/association/compliance/model	0.010s
ok  	github.com/aws/amazon-ssm-agent/agent/association/compliance/uploader	0.012s
FAIL	github.com/aws/amazon-ssm-agent/agent/association/frequentcollector [build failed]
ok  	github.com/aws/amazon-ssm-agent/agent/association/model	0.010s
FAIL	github.com/aws/amazon-ssm-agent/agent/association/processor [build failed]
ok  	github.com/aws/amazon-ssm-agent/agent/association/rateexpr	0.019s
ok  	github.com/aws/amazon-ssm-agent/agent/association/scheduleexpression	0.006s
ok  	github.com/aws/amazon-ssm-agent/agent/association/scheduler	0.010s
ok  	github.com/aws/amazon-ssm-agent/agent/association/service	0.010s
ok  	github.com/aws/amazon-ssm-agent/agent/backoffconfig	0.009s
ok  	github.com/aws/amazon-ssm-agent/agent/cli	0.008s
ok  	github.com/aws/amazon-ssm-agent/agent/contracts	0.040s
ok  	github.com/aws/amazon-ssm-agent/agent/executers	6.151s
ok  	github.com/aws/amazon-ssm-agent/agent/fileutil	0.027s
ok  	github.com/aws/amazon-ssm-agent/agent/fileutil/filelock	11.366s
FAIL	github.com/aws/amazon-ssm-agent/agent/framework/coremanager [build failed]
ok  	github.com/aws/amazon-ssm-agent/agent/framework/docparser	0.018s
ok  	github.com/aws/amazon-ssm-agent/agent/framework/docparser/parameters	0.038s
ok  	github.com/aws/amazon-ssm-agent/agent/framework/docparser/parameterstore	0.010s
ok  	github.com/aws/amazon-ssm-agent/agent/framework/processor	0.015s
ok  	github.com/aws/amazon-ssm-agent/agent/framework/processor/executer/basicexecuter	0.052s
ok  	github.com/aws/amazon-ssm-agent/agent/framework/processor/executer/iohandler	0.286s
ok  	github.com/aws/amazon-ssm-agent/agent/framework/processor/executer/iohandler/iomodule	0.015s
ok  	github.com/aws/amazon-ssm-agent/agent/framework/processor/executer/iohandler/multiwriter	0.015s
ok  	github.com/aws/amazon-ssm-agent/agent/framework/processor/executer/outofproc	10.794s
ok  	github.com/aws/amazon-ssm-agent/agent/framework/processor/executer/outofproc/messaging	0.019s
ok  	github.com/aws/amazon-ssm-agent/agent/framework/processor/executer/outofproc/proc	0.019s
FAIL	github.com/aws/amazon-ssm-agent/agent/framework/processor/executer/outofproc/sessionworker [build failed]
FAIL	github.com/aws/amazon-ssm-agent/agent/framework/processor/executer/outofproc/worker [build failed]
ok  	github.com/aws/amazon-ssm-agent/agent/framework/runpluginutil	0.175s
ok  	github.com/aws/amazon-ssm-agent/agent/health	0.109s
ok  	github.com/aws/amazon-ssm-agent/agent/hibernation	14.030s
ok  	github.com/aws/amazon-ssm-agent/agent/ipc/messagebus	0.008s
ok  	github.com/aws/amazon-ssm-agent/agent/jsonutil	0.005s
ok  	github.com/aws/amazon-ssm-agent/agent/log	0.015s
ok  	github.com/aws/amazon-ssm-agent/agent/log/ssmlog	0.009s
ok  	github.com/aws/amazon-ssm-agent/agent/longrunning/manager	0.034s
ok  	github.com/aws/amazon-ssm-agent/agent/longrunning/plugin/cloudwatch	0.013s
ok  	github.com/aws/amazon-ssm-agent/agent/managedInstances/auth	0.653s
# github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/application [github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/application.test]
build/private/src/github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/application/dataProvider.go:10:2: imported and not used: "github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/localpackages"
build/private/src/github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/application/dataProvider_unix_test.go:222:2: undefined: packageRepository
build/private/src/github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/application/dataProvider_unix_test.go:237:2: undefined: packageRepository
ok  	github.com/aws/amazon-ssm-agent/agent/managedInstances/fingerprint	45.017s
ok  	github.com/aws/amazon-ssm-agent/agent/managedInstances/registration	0.006s
ok  	github.com/aws/amazon-ssm-agent/agent/managedInstances/rolecreds	0.007s
ok  	github.com/aws/amazon-ssm-agent/agent/managedInstances/sharedCredentials	0.006s
ok  	github.com/aws/amazon-ssm-agent/agent/managedInstances/user	0.005s
ok  	github.com/aws/amazon-ssm-agent/agent/managedInstances/vault/fsvault	0.005s
ok  	github.com/aws/amazon-ssm-agent/agent/platform	0.048s
ok  	github.com/aws/amazon-ssm-agent/agent/platform/containers	2.014s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurecontainers/linuxcontainerutil	0.009s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurecontainers/windowscontainerutil	0.011s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage	0.050s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/birdwatcher	0.008s [no tests to run]
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/birdwatcher/birdwatcherarchive	0.009s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/birdwatcher/birdwatcherservice	0.018s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/birdwatcher/documentarchive	0.010s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/birdwatcher/facade/retryer	0.099s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/envdetect/ec2infradetect	0.015s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/envdetect/osdetect/darwin	0.007s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/envdetect/osdetect/linux	0.012s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/envdetect/osdetect/windows	0.015s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/localpackages	7.352s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/packageservice	0.009s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/ssminstaller	0.012s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/ssms3	0.044s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/configurepackage/trace	0.010s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/dockercontainer	0.007s [no tests to run]
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/domainjoin	0.009s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/downloadcontent	0.039s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/downloadcontent/gitresource	0.005s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/downloadcontent/gitresource/github	0.045s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/downloadcontent/gitresource/github/privategithub	0.007s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/downloadcontent/gitresource/github/privategithub/githubclient	0.005s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/downloadcontent/gitresource/privategit	0.011s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/downloadcontent/gitresource/privategit/handler	0.339s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/downloadcontent/httpresource	0.008s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/downloadcontent/httpresource/handler	0.029s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/downloadcontent/ssmdocresource	0.016s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/downloadcontent/system	0.008s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/downloadcontent/types	0.008s
FAIL	github.com/aws/amazon-ssm-agent/agent/plugins/inventory [build failed]
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/inventory/datauploader	29.014s
FAIL	github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/application [build failed]
FAIL	github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/awscomponent [build failed]
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/billinginfo	0.009s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/custom	0.014s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/file	0.009s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/instancedetailedinformation	0.009s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/registry	0.014s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/role	0.010s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/service	0.010s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/inventory/gatherers/windowsUpdate	0.011s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/inventory/model	0.005s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/pluginutil	0.030s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/rundocument	0.062s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/runscript	0.501s
ok  	github.com/aws/amazon-ssm-agent/agent/plugins/updatessmagent	2.464s
ok  	github.com/aws/amazon-ssm-agent/agent/rebooter	1.206s
ok  	github.com/aws/amazon-ssm-agent/agent/rip	0.012s
FAIL	github.com/aws/amazon-ssm-agent/agent/runcommand [build failed]
ok  	github.com/aws/amazon-ssm-agent/agent/runcommand/mds	0.015s
ok  	github.com/aws/amazon-ssm-agent/agent/s3util	0.277s
ok  	github.com/aws/amazon-ssm-agent/agent/sdkutil	0.017s
ok  	github.com/aws/amazon-ssm-agent/agent/sdkutil/retryer	7.531s
ok  	github.com/aws/amazon-ssm-agent/agent/session	0.069s
ok  	github.com/aws/amazon-ssm-agent/agent/session/communicator	0.116s
ok  	github.com/aws/amazon-ssm-agent/agent/session/communicator/websocketutil	0.103s
ok  	github.com/aws/amazon-ssm-agent/agent/session/contracts	0.009s
ok  	github.com/aws/amazon-ssm-agent/agent/session/controlchannel	0.018s
ok  	github.com/aws/amazon-ssm-agent/agent/session/crypto	0.008s
ok  	github.com/aws/amazon-ssm-agent/agent/session/datachannel	1.601s
ok  	github.com/aws/amazon-ssm-agent/agent/session/plugins/interactivecommands	0.054s
```