### PR TITLE
Contains the fix for Domain Join failure of Windows EC2 instance with AWS managed Directory when TLS1.0 is disabled on the OS

### DIFF
--- a/packaging/dependencies/AWS.DomainJoin.exe.config
+++ b/packaging/dependencies/AWS.DomainJoin.exe.config
@@ -9,6 +9,7 @@
     <add key="ClientSettingsProvider.ServiceUri" value="" />
   </appSettings>
   <runtime>
+    <AppContextSwitchOverrides value="Switch.System.Net.DontEnableSystemDefaultTlsVersions=false"/>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <probing privatePath="Ssm;Ssm\Packages;Packages;Plugins" />
       <dependentAssembly>


### PR DESCRIPTION
Contains the fix for Domain Join failure of Windows EC2 instance with AWS managed Directory when TLS1.0 is disabled on the OS

*Issue #, if available:*
Unable to domain join Windows EC2 instance with AWS Directory Service using SSM document when TLS 1.0 is disabled on the OS. The SSM command throws the following error "The client and server cannot communicate, because they do not possess a common algorithm" 

*Description of changes:*
Added the below line of code in AWS.DomainJoin.exe.config file in order to enable .Net based applications (AWS.DomainJoin.exe) to allow the operating system to choose the security protocol
<AppContextSwitchOverrides value="Switch.System.Net.DontEnableSystemDefaultTlsVersions=false"/>

Microsoft article: https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls#switchsystemnetdontenablesystemdefaulttlsversions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
