### PR TITLE
Make aws_domainjoin.sh re-runnable by exiting if domain is already joined

### DIFF
--- a/agent/plugins/domainjoin/domainjoin_unix_script.go
+++ b/agent/plugins/domainjoin/domainjoin_unix_script.go
@@ -623,6 +623,15 @@ for i in "$@"; do
     shift
 done
 
+# Deal with scenario where this script is run again after the domain is already joined.
+# We want to avoid rerunning as the set_hostname function can change the hostname of a server that is already
+# domain joined and cause a mismatch. 
+realm list | grep -q "domain-name: ${DIRECTORY_NAME}\$"
+if [ $? -eq 0 ]; then
+    echo "########## SKIPPING Domain Join: ${DIRECTORY_NAME} already joined  ##########"
+    exit 0
+fi
+
 REALM=$(echo "$DIRECTORY_NAME" | tr [a-z] [A-Z])
 
 COMPUTER_NAME=$(hostname --short)


### PR DESCRIPTION
***Issue #, if available:*** 
349

***Description of changes:*** 
aws_domainjoin.sh script modified to check whether the domain to be joined is already joined, and if so will exit cleanly. 

This is needed as the set_hostname function in the script generates a new hostname on each run, which can cause the hostname to be different to the domain joined name. 


**By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.**
