### PR TITLE
Fix prerm/postinst "Exec format error" on Squeeze

### DIFF
--- a/packaging/ubuntu/postinst
+++ b/packaging/ubuntu/postinst
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 echo "Starting agent"
 if [ $(cat /proc/1/comm) = init ]
 then

--- a/packaging/ubuntu/prerm
+++ b/packaging/ubuntu/prerm
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 echo "Stopping agent"
 if [ $(cat /proc/1/comm) = init ]
 then


### PR DESCRIPTION
The Ubuntu prerm and postinst scripts are missing "#!/bin/bash" on the first line of the script, although this is present in the preinst script. Attempting to install on Debian Squeeze fails with "Exec format error".