### PR TITLE
Support for specifying a host for port forwarding.

### DIFF
--- a/agent/session/plugins/port/port.go
+++ b/agent/session/plugins/port/port.go
@@ -39,6 +39,7 @@ const muxSupportedClientVersion = "1.1.70"
 // PortParameters contains inputs required to execute port plugin.
 type PortParameters struct {
 	PortNumber string `json:"portNumber" yaml:"portNumber"`
+	Host       string `json:"host"`
 	Type       string `json:"type"`
 }
 
@@ -65,7 +66,7 @@ var GetSession = func(context context.T, portParameters PortParameters, cancelle
 	if portParameters.Type == mgsConfig.LocalPortForwarding &&
 		versionutil.Compare(clientVersion, muxSupportedClientVersion, true) >= 0 {
 
-		if session, err = NewMuxPortSession(context, cancelled, portParameters.PortNumber, sessionId); err == nil {
+		if session, err = NewMuxPortSession(context, cancelled, portParameters.Host, portParameters.PortNumber, sessionId); err == nil {
 			return session, nil
 		}
 	} else {


### PR DESCRIPTION
Issue #208

*Description of changes:*

This is a long requested feature.
SSH has long supported forwarding ports from remote hosts, this brings similar functionality to SSM sessions.



### Session document

Ideally someone at amazon could add a host parameter to the `AWS-StartPortForwardingSession` document, or create a new public version of the document that has the host parameter.

In lieu of this, we can create one ourselves.

Create a copy of the `AWS-StartPortForwardingSession` document, and add a parameter for `host`.
For example: 
```json
{
  "schemaVersion": "1.0",
  "description": "Document to start port forwarding session over Session Manager",
  "sessionType": "Port",
  "parameters": {
    "portNumber": {
      "type": "String",
      "description": "(Optional) Port number of the server on the instance",
      "allowedPattern": "^([1-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$",
      "default": "80"
    },
    "host": {
      "type": "String",
      "description": "(Optional) Host to connect to, will default to the local target instance host",
      "default": ""
    },
    "localPortNumber": {
      "type": "String",
      "description": "(Optional) Port number on local machine to forward traffic to. An open port is chosen at run-time if not provided",
      "allowedPattern": "^([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$",
      "default": "0"
    }
  },
  "properties": {
    "portNumber": "{{ portNumber }}",
    "host": "{{ host }}",
    "type": "LocalPortForwarding",
    "localPortNumber": "{{ localPortNumber }}"
  }
}
```
```bash
# create the session document
aws ssm create-document \
    --content 'file://AWS-StartPortForwardingSessionWithHost.json' \
    --name 'Custom-AWS-StartPortForwardingSession' \
    --document-type "Session"
```

### Testing

For example, accessing RDS via an instance running SSM-Agent.
```bash
# start a port forwarding session, using a remote host
aws ssm start-session \
    --document-name 'Custom-AWS-StartPortForwardingSession' \
    --parameters 'portNumber=[3306],host=[aaaaaaa.bbbbbb.ap-southeast-2.rds.amazonaws.com],localPortNumber=[3306]' \
    --target '<instance-id>'

# in another terminal we can now access the resource at the remote host via the tunnel
mysql --host=localhost --port=3306
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
