### PR TITLE
start a session as `ssm-user` with `runAs` option 

### DIFF
--- a/agent/session/shell/shell_unix.go
+++ b/agent/session/shell/shell_unix.go
@@ -116,6 +116,12 @@ func StartCommandExecutor(
 			if strings.TrimSpace(config.RunAsUser) == "" {
 				return errors.New("please set the RunAs default user")
 			}
+			
+			if strings.TrimSpace(config.RunAsUser) == "ssm-user" {
+				// Start as ssm-user
+				// Create ssm-user before starting a session.
+				u.CreateLocalAdminUser(log)
+			}
 
 			// Check if user exists
 			if userExists, _ := u.DoesUserExist(config.RunAsUser); !userExists {


### PR DESCRIPTION
https://github.com/aws/amazon-ssm-agent/issues/217

*Issue #217, if available:*
https://github.com/aws/amazon-ssm-agent/issues/217

*Description of changes:*
If `RunAs` is enabled, and the `RunAs` user is set to `ssm-user`, the session will fail to start.

This change fixes that by allowing the user/role creating the ssm session to use `ssm-user`, and creates the account for them in the same way as when `RunAs` is not enabled.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
