### PR TITLE
Support Active Directory if joined on non-cross account

### DIFF
--- a/agent/plugins/domainjoin/domainjoin_unix_script.go
+++ b/agent/plugins/domainjoin/domainjoin_unix_script.go
@@ -287,12 +287,12 @@ get_servicecreds() {
     SECRET_ID="${SECRET_ID_PREFIX}/$DIRECTORY_ID/seamless-domain-join"
     SECRET_VALUE=$($AWSCLI secretsmanager get-secret-value --secret-id "$SECRET_ID" --region $REGION --query "SecretString"  --output text 2>/dev/null)
     if [ $? -ne 0 ]; then
-        PARENT_DIRECTORY_ID=$($AWSCLI ds describe-directories --region $REGION --query "DirectoryDescriptions[?DirectoryId =='$DIRECTORY_ID'].OwnerDirectoryDescription.DirectoryId | [0]" | sed 's/"//g')
+        PARENT_DIRECTORY_ID=$($AWSCLI ds describe-directories --region $REGION --query "DirectoryDescriptions[?DirectoryId =='$DIRECTORY_ID'].DirectoryId | [0]" | sed 's/"//g')
         if [ $? -ne 0 ] || [ -z "$PARENT_DIRECTORY_ID" ] || [ "$PARENT_DIRECTORY_ID" == null ]; then
            echo "***Failed: Cannot find parent directory Id"
            exit 1
         fi
-        PARENT_ACCOUNT_ID=$($AWSCLI ds describe-directories --region $REGION --query "DirectoryDescriptions[?DirectoryId =='$DIRECTORY_ID'].OwnerDirectoryDescription.AccountId | [0]" | sed 's/"//g')
+        PARENT_ACCOUNT_ID=$($AWSCLI ds describe-directories --region $REGION --query "DirectoryDescriptions[?DirectoryId =='$DIRECTORY_ID'].AccountId | [0]" | sed 's/"//g')
         if [ $? -ne 0 ] || [ -z "$PARENT_ACCOUNT_ID" ] || [ "$PARENT_ACCOUNT_ID" == null ]; then
            echo "***Failed: Cannot find parent account Id"
            exit 1

--- a/agent/plugins/domainjoin/domainjoin_unix_script.go
+++ b/agent/plugins/domainjoin/domainjoin_unix_script.go
@@ -287,11 +287,19 @@ get_servicecreds() {
     SECRET_ID="${SECRET_ID_PREFIX}/$DIRECTORY_ID/seamless-domain-join"
     SECRET_VALUE=$($AWSCLI secretsmanager get-secret-value --secret-id "$SECRET_ID" --region $REGION --query "SecretString"  --output text 2>/dev/null)
     if [ $? -ne 0 ]; then
-        PARENT_DIRECTORY_ID=$($AWSCLI ds describe-directories --region $REGION --query "DirectoryDescriptions[?DirectoryId =='$DIRECTORY_ID'].DirectoryId | [0]" | sed 's/"//g')
+	PARENT_DIRECTORY_ID=$($AWSCLI ds describe-directories --region $REGION --query "DirectoryDescriptions[?DirectoryId =='$DIRECTORY_ID'].DirectoryId | [0]" | sed 's/"//g')
         if [ $? -ne 0 ] || [ -z "$PARENT_DIRECTORY_ID" ] || [ "$PARENT_DIRECTORY_ID" == null ]; then
            echo "***Failed: Cannot find parent directory Id"
            exit 1
         fi
+	SHARED_DIRECTORY_ID=$($AWSCLI ds describe-directories --region $REGION --query "DirectoryDescriptions[?DirectoryId =='$DIRECTORY_ID'].OwnerDirectoryDescription.DirectoryId | [0]" | sed 's/"//g')
+        if [ $? -ne 0 ] || [ -z "$SHARED_DIRECTORY_ID" ] || [ "$SHARED_DIRECTORY_ID" == null ]; then
+           echo "No share exists, ignoring"
+	   
+        else
+	   echo "Share exists, modifying PARENT_DIRECTORY"
+	   PARENT_DIRECTORY_ID=$SHARED_DIRECTORY_ID
+	fi
         PARENT_ACCOUNT_ID=$($AWSCLI ds describe-directories --region $REGION --query "DirectoryDescriptions[?DirectoryId =='$DIRECTORY_ID'].AccountId | [0]" | sed 's/"//g')
         if [ $? -ne 0 ] || [ -z "$PARENT_ACCOUNT_ID" ] || [ "$PARENT_ACCOUNT_ID" == null ]; then
            echo "***Failed: Cannot find parent account Id"


### PR DESCRIPTION
`OwnerDirectoryDescription` does not seem to exist in the query results.... running on Centos 7.9

> aws ds describe-directories --region us-east-1 --query "DirectoryDescriptions[?DirectoryId =='d-90676a899f'].OwnerDirectoryDescription.DirectoryId | [0]" | sed 's/"//g'

Results in: null (incorrect)

--

> aws ds describe-directories --region us-east-1 --query "DirectoryDescriptions[?DirectoryId =='d-90676a899f'].DirectoryId | [0]" | sed 's/"//g'

Results in: d-* (correct)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
