### PR TITLE
use windows proxy for https

### DIFF
--- a/agent/proxyconfig/proxy_windows.go
+++ b/agent/proxyconfig/proxy_windows.go
@@ -315,9 +315,10 @@ func ParseProxySettings(log log.T, proxy string) ProxySettings {
 		HttpsProxy: https,
 	}
 
-	// If no [<scheme>=] is provided http is the default option
+	// If no [<scheme>=] is provided all schemes are handled
 	if https == nil && http == nil {
 		result.HttpProxy = other
+		result.HttpsProxy = other
 	} else if https != nil && http == nil {
 		result.HttpProxy = other
 	} else if https == nil && http != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When a proxy server is specified in Windows without a scheme restriction SSM agent should use it for both http and https calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
