### PR TITLE
Add build option for FreeBSD 386 os/architecture combination

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,16 @@ docker run -it --rm --name ssm-agent-build-container -v `pwd`:/amazon-ssm-agent 
 
 * [Cross Compile SSM Agent](https://www.ardanlabs.com/blog/2013/10/cross-compile-your-go-programs.html)
 
-* Run `make build` to build the SSM Agent for Linux, Debian, Windows environment.
+* Run `make build` to build the SSM Agent for MacOS, Linux, FreeBSD and Windows environment.
 
 * Run `make build-release` to build the agent and also packages it into a RPM, DEB and ZIP package.
 
 The following folders are generated when the build completes:
 ```
-bin/debian_386
-bin/debian_amd64
+bin/darwin_amd64
+bin/darwin_arm64
+bin/freebsd_386
+bin/freebsd_amd64
 bin/linux_386
 bin/linux_amd64
 bin/linux_arm
@@ -123,9 +125,11 @@ The following targets are available. Each may be run with `make <target>`.
 | `quick-test`             | `quick-test` runs all the tests including integration and unit tests using `go test` |
 | `coverage`               | `coverage` runs all tests and calculate code coverage |
 | `build-linux`            | `build-linux` builds the agent for execution in the Linux amd64 environment |
+| `build-freebsd`            | `build-freebsd` builds the agent for execution in the FreeBSD amd64 environment |
 | `build-windows`          | `build-windows` builds the agent for execution in the Windows amd64 environment |
 | `build-darwin`           | `build-darwin` builds the agent for execution in the Darwin amd64 environment |
 | `build-linux-386`        | `build-linux-386` builds the agent for execution in the Linux 386 environment |
+| `build-freebsd-386`        | `build-freebsd-386` builds the agent for execution in the FreeBSD 386 environment |
 | `build-windows-386`      | `build-windows-386` builds the agent for execution in the Windows 386 environment |
 | `build-darwin-386`       | `build-darwin-386` builds the agent for execution in the Darwin 386 environment |
 | `build-arm`              | `build-arm` builds the agent for execution in the arm environment |

--- a/makefile
+++ b/makefile
@@ -24,7 +24,7 @@ coverage:: build-linux
 	  github.com/aws/amazon-ssm-agent/agent/... \
 	  github.com/aws/amazon-ssm-agent/core/...
 
-build:: build-linux build-freebsd build-windows build-linux-386 build-windows-386 build-arm build-arm64 build-darwin-amd64 build-darwin-arm64
+build:: build-linux build-freebsd build-windows build-linux-386 build-freebsd-386 build-windows-386 build-arm build-arm64 build-darwin-amd64 build-darwin-arm64
 
 prepack:: cpy-plugins copy-win-dep prepack-linux prepack-linux-arm64 prepack-linux-386 prepack-windows prepack-windows-386
 
@@ -46,6 +46,8 @@ dev-build-freebsd: clean quick-integtest checkstyle pre-release build-freebsd
 dev-build-windows: clean quick-integtest checkstyle pre-release build-windows
 .PHONY: dev-build-linux-386
 dev-build-linux-386: clean quick-integtest checkstyle pre-release build-linux-386
+.PHONY: dev-build-freebsd-386
+dev-build-freebsd-386: clean quick-integtest checkstyle pre-release build-freebsd-386
 .PHONY: dev-build-windows-386
 dev-build-windows-386: clean quick-integtest checkstyle pre-release build-windows-386
 .PHONY: dev-build-arm
@@ -176,6 +178,12 @@ build-linux-386: GOOS=linux
 build-linux-386: GOARCH=386
 build-linux-386: GO_BUILD=$(GO_BUILD_NOPIE)
 build-linux-386: build-any-linux-386
+
+.PHONY: build-freebsd-386
+build-freebsd-386: GOOS=freebsd
+build-freebsd-386: GOARCH=386
+build-freebsd-386: GO_BUILD=$(GO_BUILD_NOPIE)
+build-freebsd-386: build-any-freebsd-386
 
 .PHONY: build-windows-386
 build-windows-386: GOOS=windows


### PR DESCRIPTION
Add build option for FreeBSD 386 os/architecture combination

Update the README.md accordingly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
