### PR TITLE
README: fix goreportcard URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,5 +248,5 @@ The following commands can be used to pull the `VERSION` file and check the late
 
 The Amazon SSM Agent is licensed under the Apache 2.0 License.
 
-[ReportCard-URL]: http://goreportcard.com/report/aws/amazon-ssm-agent
-[ReportCard-Image]: http://goreportcard.com/badge/aws/amazon-ssm-agent
+[ReportCard-URL]: https://goreportcard.com/report/aws/amazon-ssm-agent
+[ReportCard-Image]: https://goreportcard.com/badge/aws/amazon-ssm-agent


### PR DESCRIPTION
*Description of changes:*

The goreportcard "badge" in the README.md does not render because it uses a non-HTTPS url.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
