### PR TITLE
Update domainjoin_unix_script to fix SUSE issues

### DIFF
--- a/agent/plugins/domainjoin/domainjoin_unix_script.go
+++ b/agent/plugins/domainjoin/domainjoin_unix_script.go
@@ -390,14 +390,14 @@ install_components() {
             exit 1
          fi
          if [ "$SUSE_MAJOR_VERSION" -eq "15" ]; then
-            sudo SUSEConnect -p PackageHub/15.1/x86_64
+            sudo SUSEConnect -p PackageHub/$SUSE_MAJOR_VERSION.$SUSE_MINOR_VERSION/x86_64
             if [ $? -ne 0 ]; then
                sudo SUSEConnect
             fi
          fi
          LINUX_DISTRO='SUSE'
          sudo zypper update -y
-         sudo zypper -n install realmd adcli sssd sssd-tools sssd-ad samba-client krb5-client samba-winbind krb5-client bind-utils python3 openldap2-client NetworkManager
+         sudo zypper -n install realmd adcli sssd sssd-tools sssd-ad samba-client krb5-client samba-winbind krb5-client bind-utils python3 openldap2-client
          if [ $? -ne 0 ]; then
             return 1
          fi


### PR DESCRIPTION
*Description of changes:*

There was already variables for the SUSE distribution release and service pack but the SUSEConect to enable PackageHub was hardcoded for 15.1. Newer releases have been out for years with 15.4 being recently released in 06/2022.

It's not clear to me why NetworkManager was being installed. This should not be used on SLE Server deployments. NetworkManager is only supported by SUSE for desktop workloads with SLED or the Workstation extension. All server certifications are done with wicked as the network configuration tool and using NetworkManager may invalidate them. NetworkManager is not supported by SUSE for any server workloads.

https://doc.opensuse.org/documentation/leap/reference/html/book-reference/cha-nm.html#

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
