### PR TITLE
Update domainjoin_unix_script.go

### DIFF
--- a/agent/plugins/domainjoin/domainjoin_unix_script.go
+++ b/agent/plugins/domainjoin/domainjoin_unix_script.go
@@ -767,8 +767,6 @@ config_samba() {
         idmap config * : backend = autorid\n\
         idmap config * : range = 100000000-2100000000\n\
         idmap config * : rangesize = 100000000\n\
-        idmap config ${AD_INFO} : backend = rid\n\
-        idmap config ${AD_INFO} : range = 65536 - 99999999\n\
         winbind refresh tickets = yes\n\
         kerberos method = secrets and keytab\n\
         winbind enum groups = no\n\


### PR DESCRIPTION
*Issue #, if available:*
Currently, autorid and rid idmap backend is being used together in /etc/samba/smb.conf which is creating conflict.

*Description of changes:*
Removing the rid backend section from the script.
The idmap_autorid backend provides a way to use an algorithmic mapping scheme to map UIDs/GIDs and SIDs that is more deterministic than idmap_tdb and easier to configure than idmap_rid.

The module works similar to idmap_rid, but it automatically configures the range to be used for each domain, so there is no need to specify a specific range for each domain in the forest, the only configuration that is needed is the range of uid/gids that shall be used for user/group mappings and an optional size of the ranges to be used.

The mappings of which domain is mapped to which range is stored in autorid.tdb, thus you should backup this database regularly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
