### PR TITLE
agent/s3util: log to correct logger in `headBucketTransport.RoundTrip`

### DIFF
--- a/agent/s3util/s3util_dep.go
+++ b/agent/s3util/s3util_dep.go
@@ -116,7 +116,7 @@ func (trans headBucketTransport) RoundTrip(request *http.Request) (resp *http.Re
 	resp, err = trans.delegate.RoundTrip(request)
 	if err == nil && resp != nil && goHttpClientWillFollowRedirect(resp.StatusCode) {
 		if resp.Header != nil && resp.Header.Get("Location") == "" && resp.Header.Get(bucketRegionHeader) != "" {
-			logger.Debugf("redirect response missing Location header, overriding status code")
+			trans.logger.Debugf("redirect response missing Location header, overriding status code")
 			resp.StatusCode = 200
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:*

#473

*Description of changes:*

When the delegate responds with a status code indicating a redirect but no `Location` response header, the log message recording the status code override is sent to the package-wide mock logger defined in `test_s3util.go`, causing the message to be lost. Instead, send the message to the real logger referenced in the `headBucketTransport` struct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
