### PR TITLE
Replace mock logger with silent seelog logger

### DIFF
--- a/agent/cli/clicommand/sendcommand.go
+++ b/agent/cli/clicommand/sendcommand.go
@@ -169,7 +169,7 @@ func (SendOfflineCommand) loadContent(agentIdentity identity.IAgentIdentity, raw
 		url = url[7:]
 	}
 
-	context := context.Default(log.NewSilentMockLog(), appconfig.DefaultConfig(), agentIdentity)
+	context := context.Default(log.SilentLogger(), appconfig.DefaultConfig(), agentIdentity)
 	input := &artifact.DownloadInput{SourceURL: url}
 	if output, err := artifact.Download(context, *input); err != nil {
 		return err, content

--- a/agent/cli/cliutil/cliutil.go
+++ b/agent/cli/cliutil/cliutil.go
@@ -114,7 +114,7 @@ func ValidUrl(s string) bool {
 // GetAgentIdentity returns the agent identity and only initializes it once
 func GetAgentIdentity() (identity.IAgentIdentity, error) {
 	agentIdentityOnce.Do(func() {
-		log := logger.NewSilentMockLog()
+		log := logger.SilentLogger()
 		config := appconfig.DefaultConfig()
 
 		selector := identity.NewRuntimeConfigIdentitySelector(log)

--- a/agent/cli/diagnostics/connectivity_check.go
+++ b/agent/cli/diagnostics/connectivity_check.go
@@ -166,7 +166,7 @@ func getProxyDialer(proxyMap map[string]string) (proxy.Dialer, error) {
 			return nil, err
 		}
 
-		tlsConfig := network.GetDefaultTLSConfig(logger.NewSilentMockLog(), appconfig.DefaultConfig())
+		tlsConfig := network.GetDefaultTLSConfig(logger.SilentLogger(), appconfig.DefaultConfig())
 		return proxy.FromURL(parsedProxyUrl, &httpsDialerWrapper{tlsConfig})
 	}
 

--- a/agent/cli/diagnostics/metadata_check.go
+++ b/agent/cli/diagnostics/metadata_check.go
@@ -64,7 +64,7 @@ func (metadataCheckQuery) GetPriority() int {
 }
 
 func (metadataCheckQuery) getRegionAndInstanceId(resChan chan stringStringErrorTuple) {
-	log := logger.NewSilentMockLog()
+	log := logger.SilentLogger()
 	config := appconfig.DefaultConfig()
 
 	tr := network.GetDefaultTransport(log, config)

--- a/agent/cli/diagnostics/version_check.go
+++ b/agent/cli/diagnostics/version_check.go
@@ -57,7 +57,7 @@ func (versionQuery) GetPriority() int {
 }
 
 func (versionQuery) getLatestVersion(resChan chan versionRegionResponse) {
-	log := log.NewSilentMockLog()
+	log := log.SilentLogger()
 	config := appconfig.DefaultConfig()
 
 	agentIdentity, err := cliutil.GetAgentIdentity()

--- a/agent/cli/diagnosticsutil/diagnosticsutil.go
+++ b/agent/cli/diagnosticsutil/diagnosticsutil.go
@@ -58,7 +58,7 @@ func RegisterDiagnosticQuery(diagnosticQuery DiagnosticQuery) {
 
 // GetAwsSession create a single session and shares the session cross diagnostics queries
 func GetAwsSession(agentIdentity identity.IAgentIdentity, service string) (*session.Session, error) {
-	awsConfig := sdkutil.AwsConfig(agentContext.Default(logger.NewSilentMockLog(), appconfig.DefaultConfig(), agentIdentity), service)
+	awsConfig := sdkutil.AwsConfig(agentContext.Default(logger.SilentLogger(), appconfig.DefaultConfig(), agentIdentity), service)
 	return session.NewSession(awsConfig)
 }
 
@@ -115,7 +115,7 @@ func IsAgentInstalledSnap() bool {
 }
 
 func getRunningAgentPid() (int, error) {
-	processQuerier := executor.NewProcessExecutor(logger.NewSilentMockLog())
+	processQuerier := executor.NewProcessExecutor(logger.SilentLogger())
 
 	procs, err := processQuerier.Processes()
 

--- a/agent/cli/diagnosticsutil/diagnosticsutil_darwin.go
+++ b/agent/cli/diagnosticsutil/diagnosticsutil_darwin.go
@@ -50,7 +50,7 @@ func IsRunningElevatedPermissions() error {
 
 // AssumeAgentEnvironmentProxy is a noop on darwin because there is no other special proxy configuration
 func AssumeAgentEnvironmentProxy() {
-	proxyconfig.SetProxyConfig(log.NewSilentMockLog())
+	proxyconfig.SetProxyConfig(log.SilentLogger())
 }
 
 func GetUserRunningAgentProcess() (string, error) {

--- a/agent/cli/diagnosticsutil/diagnosticsutil_windows.go
+++ b/agent/cli/diagnosticsutil/diagnosticsutil_windows.go
@@ -189,7 +189,7 @@ func assumeAgentServiceEnvironmentProxy(proxyEnv map[string]string) {
 }
 
 func assumeInternetExplorerProxySettings(proxyEnv map[string]string) {
-	silentLog := logger.NewSilentMockLog()
+	silentLog := logger.SilentLogger()
 
 	commandFormatStr := `(Get-Item -Path 'Registry::HKEY_USERS\.DEFAULT\SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings').GetValue('%s')`
 
@@ -220,7 +220,7 @@ func assumeInternetExplorerProxySettings(proxyEnv map[string]string) {
 }
 
 func assumeWinHTTPProxySettings(proxyEnv map[string]string) {
-	silentLog := logger.NewSilentMockLog()
+	silentLog := logger.SilentLogger()
 	if isHttpOrHttpsProxyConfigured(proxyEnv) && isBypassProxyConfigured(proxyEnv) {
 		// both proxy and bypass are set, ignore winhttp
 		return

--- a/agent/log/log.go
+++ b/agent/log/log.go
@@ -46,6 +46,18 @@ func DefaultLogger() T {
 	return loadedLogger
 }
 
+// SilentLogger is a logger that discards messages sent to it. Use this in situations where a
+// function requires a log.T but messages the function sends to it need not be visible to users.
+func SilentLogger() T {
+	seelogger, _ := seelog.LoggerFromConfigAsString(`<seelog levels="off"/>`)
+
+	loggerInstance := &DelegateLogger{}
+	loggerInstance.BaseLoggerInstance = seelogger
+
+	formatFilter := &ContextFormatFilter{Context: []string{}}
+	return &Wrapper{Format: formatFilter, M: new(sync.RWMutex), Delegate: loggerInstance}
+}
+
 // ContextFormatFilter is a filter that can add a context to the parameters of a log message.
 type ContextFormatFilter struct {
 	Context []string


### PR DESCRIPTION
*Issue #, if available:*

#475

*Description of changes:*

Many packages rely on `agent/log`'s `NewSilentMockLog` in situations where a logger is required for a function call but any messages sent to it can be discarded. This introduces a dependency on the testify test toolkit in non-test code. Replace these calls to `NewSilentMockLog` with requests for a new real seelog logger that simply discards any messages sent to it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
