### PR TITLE
Support CIDR entries in DeniedPortForwardingRemoteIPs list

### DIFF
--- a/agent/session/plugins/port/port_test.go
+++ b/agent/session/plugins/port/port_test.go
@@ -334,7 +334,7 @@ func (suite *PortTestSuite) TestValidateParametersWhenDefaultDenylistHostNotAllo
 	mockContext := &context.Mock{}
 	suite.plugin.context = mockContext
 
-	mockContext.On("AppConfig").Return(appconfig.SsmagentConfig{Mgs: appconfig.MgsConfig{DeniedPortForwardingRemoteIPs: []string{"169.254.169.254", "fd00:ec2::254", "169.254.169.253", "fd00:ec2::253", "169.254.169.123", "169.254.169.250"}}})
+	mockContext.On("AppConfig").Return(appconfig.SsmagentConfig{Mgs: appconfig.MgsConfig{DeniedPortForwardingRemoteIPs: []string{"169.254.169.254", "fd00:ec2::254", "169.254.169.253", "fd00:ec2::253", "169.254.169.123", "169.254.169.250", "10.0.0.0/16"}}})
 	mockContext.On("Log").Return(mockLog)
 
 	err := suite.plugin.validateParameters(PortParameters{PortNumber: "80", Host: "169.254.169.253"}, configuration)
@@ -349,7 +349,8 @@ func (suite *PortTestSuite) TestValidateParametersWhenDefaultDenylistHostNotAllo
 	assert.Contains(suite.T(), err.Error(), "Forwarding to IP address 169.254.169.250 is forbidden.")
 	err = suite.plugin.validateParameters(PortParameters{PortNumber: "80", Host: "169.254.169.123"}, configuration)
 	assert.Contains(suite.T(), err.Error(), "Forwarding to IP address 169.254.169.123 is forbidden.")
-
+	err = suite.plugin.validateParameters(PortParameters{PortNumber: "80", Host: "10.0.15.24"}, configuration)
+	assert.Contains(suite.T(), err.Error(), "Forwarding to IP address 10.0.15.24 is forbidden.")
 	mockContext.AssertExpectations(suite.T())
 }
 
@@ -357,10 +358,12 @@ func (suite *PortTestSuite) TestValidateParametersWhenValidHostAndPort() {
 	mockContext := &context.Mock{}
 	suite.plugin.context = mockContext
 
-	mockContext.On("AppConfig").Return(appconfig.SsmagentConfig{Mgs: appconfig.MgsConfig{DeniedPortForwardingRemoteIPs: []string{"169.254.169.254", "fd00:ec2::254", "169.254.169.253", "fd00:ec2::253"}}})
+	mockContext.On("AppConfig").Return(appconfig.SsmagentConfig{Mgs: appconfig.MgsConfig{DeniedPortForwardingRemoteIPs: []string{"169.254.169.254", "fd00:ec2::254", "169.254.169.253", "fd00:ec2::253", "10.0.0.0/16"}}})
 	mockContext.On("Log").Return(mockLog)
 
 	err := suite.plugin.validateParameters(PortParameters{PortNumber: "80", Host: "127.0.0.1"}, configuration)
+	assert.Nil(suite.T(), err)
+	err = suite.plugin.validateParameters(PortParameters{PortNumber: "80", Host: "10.1.0.4"}, configuration)
 	assert.Nil(suite.T(), err)
 
 	mockContext.AssertExpectations(suite.T())


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-ssm-agent/issues/480

*Description of changes:*
This PR provides a way of defining IP address ranges in the configuration for what addresses should be forbidden to be port-forwarded. It piggy-backs on the implementation of the original list of forbidden IP addresses by checking whether an item is in CIDR format in order to perform the correct type of IP address comparison. This is completely backward-compatible. Unit tests have been updated and are passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
