### PR TITLE
[SeamlessDomainJoin] Ubuntu - Retrieve and set interface name dynamically

### DIFF
--- a/agent/plugins/domainjoin/domainjoin_unix_script.go
+++ b/agent/plugins/domainjoin/domainjoin_unix_script.go
@@ -602,11 +602,12 @@ do_dns_config() {
     if [ $LINUX_DISTRO = "UBUNTU" ]; then
         if [ -d /etc/netplan ]; then
             # Ubuntu 18.04
+            if_name=$(ip route list | grep default | grep -E  'dev (\w+)' -o | awk '{print $2}')
             cat << EOF | tee /etc/netplan/99-custom-dns.yaml
 network:
     version: 2
     ethernets:
-        eth0:
+        $if_name:
             nameservers:
                 addresses: [$INPUT_DNS_IP_ADDRESS1, $INPUT_DNS_IP_ADDRESS2]
             dhcp4-overrides:


### PR DESCRIPTION
SeamlessDomainJoin has been configured to retrieve interface name dynamically everywhere but the `do_dns_config` function

*Issue #, if available:*
[469](https://github.com/aws/amazon-ssm-agent/issues/469)

*Description of changes:*
As per issue [469](https://github.com/aws/amazon-ssm-agent/issues/469) newer tX (t3 and above) EC2 instances now use interface names of `ensX` as opposed to `eth0`

Issue #[469](https://github.com/aws/amazon-ssm-agent/issues/469) / PR #[470](https://github.com/aws/amazon-ssm-agent/pull/470) has been opened and merged to remediate this however the `do_dns_config` function needs to be added to configure the interface name dynamically also. This PR/merge request handles this and has been tested.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
