### PR TITLE
Update to golang:1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.19
 
 RUN apt -y update && apt -y upgrade && apt -y install rpm tar gzip wget zip && apt clean all
 


### PR DESCRIPTION
Please update to golang:1.19 or higher.

Some CVEs associated with golang:1.18.3:
- https://nvd.nist.gov/vuln/detail/CVE-2022-41715
- https://nvd.nist.gov/vuln/detail/CVE-2022-2879
- https://nvd.nist.gov/vuln/detail/CVE-2022-2880
- https://nvd.nist.gov/vuln/detail/CVE-2022-32190

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
