### PR TITLE
feat - Add support for excluding certain interfaces when reporting to…

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,6 +8,7 @@ Latest
 - Adjusted random number generator logic used to get filename in downloadContent plugin
 - Fixed Agent to gather application inventory from both rpm and dpkg package managers if present in Unix instances
 - Bump golang.org/x/crypto/ssh from 0.14.0 to 0.17.0
+- Added EXCLUDE\_INTERFACES environment variable support to exclude certain interfaces
 
 3.2.2016.0
 ===============

--- a/agent/platform/platform.go
+++ b/agent/platform/platform.go
@@ -17,10 +17,13 @@ package platform
 import (
 	"fmt"
 	"net"
+	"os"
 	"sort"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/aws/amazon-ssm-agent/agent/log"
+	"github.com/aws/amazon-ssm-agent/agent/ssm/util"
 )
 
 const (
@@ -144,8 +147,15 @@ func isIpv4(ip net.IP) bool {
 
 // filterInterface removes interface that's not up or is a loopback/p2p
 func filterInterface(interfaces []net.Interface) (i []net.Interface) {
+	excludeInterfacesStr := os.Getenv("EXCLUDE_INTERFACES")
+
+	excludeInterfaces := []string{}
+	if excludeInterfacesStr != "" {
+		excludeInterfaces = strings.Split(excludeInterfacesStr, ",")
+	}
+
 	for _, v := range interfaces {
-		if (v.Flags&net.FlagUp != 0) && (v.Flags&net.FlagLoopback == 0) && (v.Flags&net.FlagPointToPoint == 0) {
+		if (v.Flags&net.FlagUp != 0) && (v.Flags&net.FlagLoopback == 0) && (v.Flags&net.FlagPointToPoint == 0 && !util.Contains(excludeInterfaces, v.Name)) {
 			i = append(i, v)
 		}
 	}

--- a/agent/ssm/util/util.go
+++ b/agent/ssm/util/util.go
@@ -68,3 +68,13 @@ func disableHTTPDowngrade(req *http.Request, via []*http.Request) error {
 	}
 	return nil
 }
+
+func Contains(slice []string, str string) bool {
+	// contains checks if a string is present in a slice
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
… AWS

Fixes https://github.com/aws/amazon-ssm-agent/issues/553


*Description of changes:*

This adds a new environment variable that one can use to exclude the interface from being reported to AWS. You just need to add `EXCLUDE_INTERFACES=docker0,interfaceX` to the service's environment (using systemd for example).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
