### PR TITLE
greengrass component: adjust minimal architecture to match Go binary

### DIFF
--- a/packaging/greengrass/component.json
+++ b/packaging/greengrass/component.json
@@ -62,7 +62,7 @@
       {
         "Platform": {
           "os": "linux",
-          "architecture": "/aarch64|armv8/"
+          "architecture": "/aarch64|arm/"
         },
         "Lifecycle": {
           "SetEnv": {


### PR DESCRIPTION
SSM-Agent is already compiled and tested for armv6 ([see makefile GOARM](https://github.com/aws/amazon-ssm-agent/blob/da9a3363e1d1a04cc69e7aba71bd33844a376eac/makefile#L211)), so changing the GG component recipe brings it down to match the minimal architecture version. GG Nucleus requires at least armv7l, so the regex for the architecture can be shortened accordingly. This matches the recommended best practice of other AWS-provided Greengrass components.

See `Platform.architecture` recipe key:
https://docs.aws.amazon.com/greengrass/v2/developerguide/component-recipe-reference.html#recipe-format

See "Supported platforms" of Greengrass Nucleus:
https://docs.aws.amazon.com/greengrass/v2/developerguide/setting-up.html#installation-requirements

*Issue #, if available:*
https://github.com/aws/amazon-ssm-agent/issues/539
https://github.com/aws/amazon-ssm-agent/issues/445


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
