### PR TITLE
Add Wants=network-online.target

### DIFF
--- a/packaging/linux/amazon-ssm-agent.service
+++ b/packaging/linux/amazon-ssm-agent.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=amazon-ssm-agent
+Wants=network-online.target
 After=network-online.target
 
 [Service]


### PR DESCRIPTION
*Description of changes:*

`After=network-online.target` without `Wants=network-online.target` doesn't actually do anything (unless by mere luck another service also has a `Wants=network-online.target` in the same transaction).

This is because `network-online.target` isn't pulled into the boot transaction by default by systemd to minimize delay of booting if no services require network connectivity.  Services that require network connectivity should explicitly pull it in (through a `Wants=`).

There's an entire FAQ page dedicated to this bug here: https://systemd.io/NETWORK_ONLINE/

> Note that normally, if no service requires it and if no remote mount point is configured, this target is not pulled into the boot, thus avoiding any delays during boot should the network not be available. 


> How do I make sure that my service starts after the network is really online?
> That depends on your setup and the services you plan to run after it (see above). If you need to delay you service after network connectivity has been established, include
> 
> ```
> After=network-online.target
> Wants=network-online.target
> ```
> in the .service file.
> 
> This will delay boot until the network management software > says the network is “up”. For details, see the next question.

*Issue #, if available:*



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
