### PR TITLE
Update amazon-ssm-agent systemd unit files to start after important services on boot

### DIFF
--- a/packaging/linux/amazon-ssm-agent.service
+++ b/packaging/linux/amazon-ssm-agent.service
@@ -1,6 +1,9 @@
 [Unit]
-Description=amazon-ssm-agent
-After=network-online.target
+Description=Amazon SSM Agent
+Documentation=https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html
+Wants=network-online.target
+After=network-online.target nss-lookup.target cloud-init.target
+ConditionFileIsExecutable=/usr/bin/amazon-ssm-agent
 
 [Service]
 Type=simple

--- a/packaging/ubuntu/amazon-ssm-agent.service
+++ b/packaging/ubuntu/amazon-ssm-agent.service
@@ -1,6 +1,9 @@
 [Unit]
-Description=amazon-ssm-agent
-After=network-online.target
+Description=Amazon SSM Agent
+Documentation=https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html
+Wants=network-online.target
+After=network-online.target nss-lookup.target cloud-init.target
+ConditionFileIsExecutable=/usr/bin/amazon-ssm-agent
 
 [Service]
 Type=simple


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The Amazon SSM Agent should be started after networking and dns available and should not start until after cloud-init has finished to prevent yum/dnf lock contention like issues.

- https://systemd.io/NETWORK_ONLINE/
- https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

There's numerous threads of AL2023 and lock contention issues.

- https://repost.aws/questions/QU_tj7NQl6ReKoG53zzEqYOw/amazon-linux-2023-issue-with-installing-packages-with-cloud-init
- https://repost.aws/questions/QULl6jRiWxQpiefbOfGcObdg/linux-error-another-app-is-currently-holding-the-yum-lock-waiting-for-it-to-exit-the-other-application-is-yum


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
