### PR TITLE
fix(windows): refactor start and stop agent to not rely on $PSCulture

### DIFF
--- a/agent/setupcli/managers/servicemanagers/windowsmanager.go
+++ b/agent/setupcli/managers/servicemanagers/windowsmanager.go
@@ -43,14 +43,9 @@ func (m *windowsManager) StartAgent() error {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ec := exitError.ExitCode()
 			// NET HELPMSG 2182 : The requested service has already been started.
-			if ec == 2182 {
+			if ec == 2 {
 				return nil
 			}
-		}
-		output = strings.ToLower(output)
-		if strings.Contains(output, "service has already been started") {
-			// service already running
-			return nil
 		}
 		return fmt.Errorf("windows: failed to start agent with output '%s' and error: %v", output, err)
 	}
@@ -64,14 +59,9 @@ func (m *windowsManager) StopAgent() error {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ec := exitError.ExitCode()
 			//NET HELPMSG 3521 : The *** service is not started.
-			if ec == 3521 {
+			if ec == 2 {
 				return nil
 			}
-		}
-		output = strings.ToLower(output)
-		if strings.Contains(output, "service is not started") {
-			// Service is already stopped
-			return nil
 		}
 		return fmt.Errorf("windows: failed to stop agent with output '%s' and error: %v", output, err)
 	}

--- a/agent/setupcli/managers/servicemanagers/windowsmanager.go
+++ b/agent/setupcli/managers/servicemanagers/windowsmanager.go
@@ -58,7 +58,7 @@ func (m *windowsManager) StopAgent() error {
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ec := exitError.ExitCode()
-			//NET HELPMSG 3521 : The *** service is not started.
+			// NET HELPMSG 3521 : The *** service is not started.
 			if ec == 2 {
 				return nil
 			}


### PR DESCRIPTION


fixes #604

*Description of changes:*

refactor start and stop agent to not rely on $PSCulture en-US

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
