### PR TITLE
Update golang.org/x/crypto to 0.32.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/xtaci/smux v1.5.15
 	github.com/yusufpapurcu/wmi v1.2.4
 	go.nanomsg.org/mangos/v3 v3.3.0
-	golang.org/x/crypto v0.24.0
+	golang.org/x/crypto v0.32.0
 	golang.org/x/net v0.26.0
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1
 	golang.org/x/sync v0.3.0


### PR DESCRIPTION
*Issue* https://github.com/aws/amazon-ssm-agent/issues/612

*Description of changes:*
Update dependency golang.org/x/crypto to version 0.32.0. This fixes a critical vulnerability


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
