### PR TITLE
Update AWS.DomainJoin.exe.config to resolve unhandled exception on Windows domain join

### DIFF
--- a/packaging/dependencies/AWS.DomainJoin.exe.config
+++ b/packaging/dependencies/AWS.DomainJoin.exe.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <startup>
+  <startup useLegacyV2RuntimeActivationPolicy="true">
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0,Profile=Client" />
     <supportedRuntime version="v2.0.50727" />
   </startup>


### PR DESCRIPTION
*Description of changes:*

This update resolves an error we are seeing when attempting to join a Windows EC2 instance to our Active Directory domain.

The error can be seen when running the `AWS-JoinDirectoryServiceDomain` or `AWS-JoinDirectoryServiceDomain-V2` documents, or when running a custom document that uses the [aws:domainJoin](https://docs.aws.amazon.com/systems-manager/latest/userguide/documents-command-ssm-plugin-reference.html#aws-domainJoin) action.

![image](https://github.com/user-attachments/assets/0a18d8a1-df71-431a-98a1-315106094558)

The `stderr` output is

> Unhandled Exception: System.IO.FileLoadException: Mixed mode assembly is built against version 'v2.0.50727' of the runtime and cannot be loaded in the 4.0 runtime without additional configuration information.
> exit status 1

Additionally, the error can be replicated by running the `AWS.DomainJoin.exe` directly.

```
PS C:\Program Files\Amazon\SSM\Plugins\awsDomainJoin> ls AWS.DomainJoin.*


    Directory: C:\Program Files\Amazon\SSM\Plugins\awsDomainJoin


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         1/10/2025   1:10 AM          58000 AWS.DomainJoin.exe
-a----         1/10/2025   1:05 AM           1927 AWS.DomainJoin.exe.config


PS C:\Program Files\Amazon\SSM\Plugins\awsDomainJoin> .\AWS.DomainJoin.exe

Unhandled Exception: System.IO.FileLoadException: Mixed mode assembly is built against version 'v2.0.50727' of the runtime and cannot be loaded in the 4.0 runtime without additional configuration information.

PS C:\Program Files\Amazon\SSM\Plugins\awsDomainJoin> $LASTEXITCODE
-532462766
```

The solution to add `useLegacyV2RuntimeActivationPolicy="true"` was recommended in this [stack overflow post](https://stackoverflow.com/questions/6425707/mixed-mode-assembly-is-built-against-version-v2-0-50727-of-the-runtime) and confirmed in the [documentation](https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/startup/startup-element#uselegacyv2runtimeactivationpolicy-attribute).

Additionally, I have tested the solution by updating the `AWS.DomainJoin.exe.config` file to include the `useLegacyV2RuntimeActivationPolicy="true"` property and then re-running the exe and SSM document.

```
PS C:\Program Files\Amazon\SSM\Plugins\awsDomainJoin> cat .\AWS.DomainJoin.exe.config -Head 5
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <startup useLegacyV2RuntimeActivationPolicy="true">
    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0,Profile=Client" />
    <supportedRuntime version="v2.0.50727" />

PS C:\Program Files\Amazon\SSM\Plugins\awsDomainJoin> .\AWS.DomainJoin.exe
Domain join failed with exception: Domain Join failed
```

![image](https://github.com/user-attachments/assets/8677e7c5-04b1-4888-9628-8b016abeefc7)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.