### PR TITLE
Add --no-tty to gpg commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.iml
 .project
 .DS_Store
+.vscode/
 /bin/
 /pkg/
 /.settings/

--- a/agent/setupcli/managers/verificationmanagers/linuxmanager.go
+++ b/agent/setupcli/managers/verificationmanagers/linuxmanager.go
@@ -19,11 +19,12 @@ package verificationmanagers
 
 import (
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
 	"github.com/aws/amazon-ssm-agent/agent/appconfig"
 	"github.com/aws/amazon-ssm-agent/agent/log"
 	"github.com/aws/amazon-ssm-agent/agent/setupcli/managers/common"
-	"io/ioutil"
-	"path/filepath"
 )
 
 var (
@@ -72,7 +73,7 @@ func (l *linuxManager) VerifySignature(log log.T, signaturePath string, artifact
 	}
 
 	log.Debugf("Importing public key: gpg --import %s", amazonSSMAgentGPGKey)
-	output, err := l.managerHelper.RunCommand("gpg", "--no-default-keyring", "--keyring", keyringFile, "--import", amazonSSMAgentGPGKey)
+	output, err := l.managerHelper.RunCommand("gpg", "--no-tty", "--no-default-keyring", "--keyring", keyringFile, "--import", amazonSSMAgentGPGKey)
 	if err != nil {
 		if l.managerHelper.IsTimeoutError(err) {
 			return fmt.Errorf("gpg command timed out")
@@ -81,7 +82,7 @@ func (l *linuxManager) VerifySignature(log log.T, signaturePath string, artifact
 	log.Infof("Successfully imported keyring: %v", output)
 
 	log.Info("Verifying agent signature")
-	output, err = l.managerHelper.RunCommand("gpg", "--no-default-keyring", "--keyring", keyringFile, "--verify", signaturePath, binaryPath)
+	output, err = l.managerHelper.RunCommand("gpg", "--no-tty", "--no-default-keyring", "--keyring", keyringFile, "--verify", signaturePath, binaryPath)
 	if err != nil {
 		if l.managerHelper.IsTimeoutError(err) {
 			return fmt.Errorf("gpg verify: command timed out")

--- a/agent/setupcli/managers/verificationmanagers/linuxmanager_test.go
+++ b/agent/setupcli/managers/verificationmanagers/linuxmanager_test.go
@@ -58,8 +58,8 @@ func (suite *VerificationManagerLinuxTestSuite) TestVerificationManager_Success(
 	fileExtension := ".deb"
 	binaryPath := filepath.Join(artifactsPath, appconfig.DefaultAgentName+fileExtension)
 	mgrHelper.On("IsCommandAvailable", "gpg").Return(true)
-	mgrHelper.On("RunCommand", "gpg", "--no-default-keyring", "--keyring", keyringFile, "--import", amazonSSMAgentGPGKey).Return("status: accepted sample output", nil).Once()
-	mgrHelper.On("RunCommand", "gpg", "--no-default-keyring", "--keyring", keyringFile, "--verify", signaturePath, binaryPath).Return("Good signature from \"SSM Agent <ssm-agent-signer@amazon.com>\"", nil).Once()
+	mgrHelper.On("RunCommand", "gpg", "--no-tty", "--no-default-keyring", "--keyring", keyringFile, "--import", amazonSSMAgentGPGKey).Return("status: accepted sample output", nil).Once()
+	mgrHelper.On("RunCommand", "gpg", "--no-tty", "--no-default-keyring", "--keyring", keyringFile, "--verify", signaturePath, binaryPath).Return("Good signature from \"SSM Agent <ssm-agent-signer@amazon.com>\"", nil).Once()
 
 	pkgManagerRef := linuxManager{managerHelper: mgrHelper}
 	err := pkgManagerRef.VerifySignature(suite.logMock, signaturePath, artifactsPath, fileExtension)
@@ -85,9 +85,9 @@ func (suite *VerificationManagerLinuxTestSuite) TestVerificationManager_Failure(
 	gpgErr := errors.New("exit status 1")
 	binaryPath := filepath.Join(artifactsPath, appconfig.DefaultAgentName+fileExtension)
 	mgrHelper.On("IsCommandAvailable", "gpg").Return(true)
-	mgrHelper.On("RunCommand", "gpg", "--no-default-keyring", "--keyring", keyringFile, "--import", amazonSSMAgentGPGKey).Return("status: accepted sample output", nil).Once()
+	mgrHelper.On("RunCommand", "gpg", "--no-tty", "--no-default-keyring", "--keyring", keyringFile, "--import", amazonSSMAgentGPGKey).Return("status: accepted sample output", nil).Once()
 	mgrHelper.On("IsTimeoutError", gpgErr).Return(false)
-	mgrHelper.On("RunCommand", "gpg", "--no-default-keyring", "--keyring", keyringFile, "--verify", signaturePath, binaryPath).Return("Bad signature from \"SSM Agent <ssm-agent-signer@amazon.com>\"", gpgErr).Once()
+	mgrHelper.On("RunCommand", "gpg", "--no-tty", "--no-default-keyring", "--keyring", keyringFile, "--verify", signaturePath, binaryPath).Return("Bad signature from \"SSM Agent <ssm-agent-signer@amazon.com>\"", gpgErr).Once()
 
 	pkgManagerRef := linuxManager{managerHelper: mgrHelper}
 	err := pkgManagerRef.VerifySignature(suite.logMock, signaturePath, artifactsPath, fileExtension)


### PR DESCRIPTION
*Description of changes:*
Sometimes GPG commands invoke tty to output messages. In environments where tty isnt configured or available, gpg commands to add key and verify the signature fails. This change adds a `--no-tty` option to the gpg commands which prevent it from invoking tty and failing mid-process.

Ref: https://www.gnupg.org/documentation/manuals/gnupg/GPG-Configuration-Options.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
