### PR TITLE
Issue 170, fix for failure of remote session connection when disk is full

### DIFF
--- a/agent/session/shell/shell.go
+++ b/agent/session/shell/shell.go
@@ -281,11 +281,14 @@ func (p *ShellPlugin) execute(config agentContracts.Configuration,
 		output.MarkAsFailed(errorString)
 		return
 	}
-	defer func() {
-		if closeErr := ipcFile.Close(); closeErr != nil {
-			log.Warnf("error occurred while closing ipcFile, %v", closeErr)
-		}
-	}()
+	// Only defer Close if the file was actually created.
+	if ipcFile != nil {
+		defer func() {
+			if closeErr := ipcFile.Close(); closeErr != nil {
+				log.Warnf("error occurred while closing ipcFile, %v", closeErr)
+			}
+		}()
+	}
 
 	go func() {
 		cancelState := cancelFlag.Wait()
@@ -314,7 +317,40 @@ func (p *ShellPlugin) createIpcFile() (*os.File, error) {
 		return nil, nil
 	}
 	ipcFile, err := os.Create(p.logger.ipcFilePath)
-	return ipcFile, err
+
+	// If file creation fails, check for a "no space left on device" error.
+	if err != nil {
+		// Check underlying error
+		if isDiskFull(err) {
+			p.context.Log().Warn("Disk is full. Session will start without logging to disk.")
+			p.logger.writeToIpcFile = false
+			return nil, nil
+		}
+		// For any other error, fail the session as normal.
+		return nil, err
+	}
+
+	return ipcFile, nil
+}
+
+func isDiskFull(err error) bool {
+	// Check string error message (fallback)
+	if strings.Contains(err.Error(), "no space left on device") || // Unix
+		strings.Contains(err.Error(), "disk is full") || // Windows
+		strings.Contains(err.Error(), "not enough space") {
+		return true
+	}
+
+	// Check syscall.Errno on Unix/Linux/Windows
+	if errno, ok := err.(syscall.Errno); ok {
+		return errno == syscall.ENOSPC // Unix
+	}
+	if pathErr, ok := err.(*os.PathError); ok {
+		if errno, ok := pathErr.Err.(syscall.Errno); ok {
+			return errno == syscall.ENOSPC
+		}
+	}
+	return false
 }
 
 // Executes command in pseudo terminal with pty


### PR DESCRIPTION
Issue 170

When writing shell commands and no S3 or CloudWatch remote logging configuration was configured, SSM would write to a local file and fail if the disk was full, as the file could not be created, which meant remote connectivity was lost requiring extensive manual recovery.

This patch checks for the presence of an out of disk error and disables this logging and continues anyway, the ability to connect at this point is far more important than local logging as otherwise you lose connectivity to the VM completely.

I have tested this on Linux and can no longer reproduce the error on full disk when connecting remotely via SSM.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.