### PR TITLE
Fix frequentcollector Error Messages

### DIFF
--- a/agent/association/frequentcollector/frequentcollector.go
+++ b/agent/association/frequentcollector/frequentcollector.go
@@ -301,16 +301,19 @@ func (collector *FrequentCollector) getValidInventoryGathererConfigMap(context c
 	}
 
 	if dataB, err = json.Marshal(pluginState.Configuration.Properties); err != nil {
-		log.Error("error occurred while json.Marshal(pluginState.Configuration.Properties)")
+		log.Errorf("error occurred while json.Marshal(pluginState.Configuration.Properties): %s", err)
 		return
 	}
 
 	if err = json.Unmarshal(dataB, &inventoryInput); err != nil {
-		log.Error("error occurred while json.Unmarshal(dataB, &inventoryInput)")
+		log.Errorf("error occurred while json.Unmarshal(dataB, &inventoryInput): %s", err)
 		return
 	}
 	log.Debugf("unmarshal channel response: %v", inventoryInput)
 	validGatherers, err = plugin.ValidateInventoryInput(context, inventoryInput)
+	if err != nil {
+		log.Errorf("error occured validating inventory input: %s", err)
+	}
 	return
 }
 


### PR DESCRIPTION
This logs the `err` from `plugin.ValidateInventoryInput()` that was previously being discarded in silence.

Additionally, the other error messages in the function did not specify the error that caused a message to show up in the logs. This adds the `err` to the logline with a `%s`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
