### PR TITLE
Add Wind River Linux platform support and RPM packaging

### DIFF
--- a/BUILD_WRLINUX.md
+++ b/BUILD_WRLINUX.md
@@ -1,0 +1,260 @@
+# Building Amazon SSM Agent for Wind River Linux LTS
+
+## Target
+
+- **OS**: Wind River Linux LTS 22.33 Update 16 (`wrlinux`, VERSION_ID=10.22.33.16)
+- **Architecture**: x86_64 (amd64)
+- **Init system**: systemd
+
+## Prerequisites
+
+### On the build host (macOS / standard Linux)
+
+- **Go 1.24+** (go.mod specifies 1.25, Docker uses 1.24)
+- **make**
+- No C compiler needed if using the static build (CGO_ENABLED=0)
+
+### On the Wind River Linux target (runtime)
+
+- **systemd** — service management
+- **`/etc/machine-id`** — provided by systemd, used for instance fingerprint
+- **`/usr/sbin/dmidecode`** — hardware fingerprint (optional, agent continues without it)
+- **`/bin/hostname`** — FQDN detection
+- **`rpm`** — required for self-update install/uninstall scripts
+- **Network access** to AWS SSM endpoints
+
+## Source Code Changes
+
+The following files were modified to add Wind River Linux platform recognition:
+
+| File | Change |
+|------|--------|
+| `agent/plugins/configurepackage/envdetect/constants/constants.go` | Added `PlatformWindRiver = "wrlinux"` constant |
+| `agent/plugins/configurepackage/envdetect/osdetect/osdetect_unix.go` | Added `wrlinux` to OS-release ID mapping; mapped to `rhel` family (RPM-based) |
+| `agent/updateutil/updateconstants/constants.go` | Added `PlatformWindRiver = "wind river"` constant |
+| `agent/updateutil/updateinfo/updateinfo.go` | Added WR Linux to platform detection chain (uses `linux` download path); added to `possiblyUsingSystemD` map |
+
+### Why these changes are needed
+
+Without them, the agent reads `/etc/os-release` and gets `ID=wrlinux` / `NAME="Wind River Linux LTS"`. Neither value matches any known platform in the codebase, causing:
+
+1. Platform detection falls through to the Windows/Nano path (incorrect)
+2. Package manager detection fails (`configurePackage` plugin unusable)
+3. Self-update downloads the wrong artifact
+
+## Build Instructions
+
+### Option A: Static Build — CGO_ENABLED=0 (Recommended)
+
+Produces fully static Go binaries with **zero glibc dependency**. Best for embedded/minimal WR Linux images.
+
+```bash
+cd /path/to/amazon-ssm-agent
+
+# Clean previous builds
+rm -rf bin/linux_amd64
+
+# Build all 8 binaries
+make copy-src pre-build
+cd build/private/src/github.com/aws/amazon-ssm-agent
+
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath \
+  -o ../../../../../../bin/linux_amd64/amazon-ssm-agent -v \
+  core/agent.go core/agent_unix.go core/agent_parser.go
+
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath \
+  -o ../../../../../../bin/linux_amd64/ssm-agent-worker -v \
+  agent/agent.go agent/agent_unix.go agent/agent_parser.go
+
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath \
+  -o ../../../../../../bin/linux_amd64/updater -v \
+  agent/update/updater/updater.go agent/update/updater/updater_unix.go
+
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath \
+  -o ../../../../../../bin/linux_amd64/ssm-cli -v \
+  agent/cli-main/cli-main.go
+
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath \
+  -o ../../../../../../bin/linux_amd64/ssm-document-worker -v \
+  agent/framework/processor/executer/outofproc/worker/main.go
+
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath \
+  -o ../../../../../../bin/linux_amd64/ssm-session-logger -v \
+  agent/session/logging/main.go
+
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath \
+  -o ../../../../../../bin/linux_amd64/ssm-session-worker -v \
+  agent/framework/processor/executer/outofproc/sessionworker/main.go
+
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath \
+  -o ../../../../../../bin/linux_amd64/ssm-setup-cli -v \
+  agent/setupcli/setupcli.go
+
+cd -
+```
+
+Or use the Makefile shortcut (overriding GO_BUILD):
+
+```bash
+make copy-src pre-build
+GOOS=linux GOARCH=amd64 GO_BUILD="CGO_ENABLED=0 go build -ldflags '-s -w' -trimpath" \
+  make build-any-amd64-linux
+```
+
+### Option B: Docker Build (Reproducible)
+
+Uses the project's Dockerfile for a clean build environment:
+
+```bash
+docker build -t ssm-agent-build-image .
+docker run -it --rm --name ssm-agent-build \
+  -v $(pwd):/amazon-ssm-agent \
+  ssm-agent-build-image \
+  make build-linux
+```
+
+This produces PIE binaries (with CGO) linked against the container's glibc. Verify glibc compatibility with your WR Linux target.
+
+### Option C: PIE Build with WR Linux SDK Cross-Compiler
+
+If your security policy requires PIE + RELRO hardening:
+
+```bash
+# Point CC to the WR Linux SDK cross-compiler
+export CC=x86_64-wrs-linux-gnu-gcc
+export CGO_ENABLED=1
+
+GOOS=linux GOARCH=amd64 \
+  GO_BUILD='go build -ldflags "-s -w -extldflags=-Wl,-z,now,-z,relro,-z,defs" -buildmode=pie -trimpath' \
+  make build-any-amd64-linux
+```
+
+## Build & Package as RPM (Recommended)
+
+The simplest approach: one script builds everything and produces an installable RPM.
+
+### Prerequisites (build host — macOS)
+
+```bash
+brew install go rpm
+```
+
+### Build the RPM
+
+```bash
+cd /path/to/amazon-ssm-agent
+chmod +x packaging/wrlinux/create_rpm.sh
+./packaging/wrlinux/create_rpm.sh
+```
+
+Output: `bin/linux_amd64/amazon-ssm-agent-3.3.0.0.wrlinux.x86_64.rpm`
+
+### Deploy to Wind River Linux
+
+```bash
+# Copy RPM to target
+scp bin/linux_amd64/amazon-ssm-agent-*.wrlinux.x86_64.rpm root@<host>:/tmp/
+
+# Install (first time)
+ssh root@<host> rpm -i /tmp/amazon-ssm-agent-*.wrlinux.x86_64.rpm
+
+# Upgrade (subsequent updates)
+ssh root@<host> rpm -U /tmp/amazon-ssm-agent-*.wrlinux.x86_64.rpm
+
+# Uninstall
+ssh root@<host> rpm -e amazon-ssm-agent
+```
+
+The RPM automatically:
+
+- Installs binaries to `/usr/bin/`
+- Installs config to `/etc/amazon/ssm/`
+- Installs SysVinit init script to `/etc/init.d/amazon-ssm-agent`
+- Creates `/var/lib/amazon/ssm/` and `/var/log/amazon/ssm/`
+- Enables the service at boot via rc symlinks
+- Starts the agent on install, restarts on upgrade, stops on uninstall
+- Creates `/etc/machine-id` if missing (needed for instance fingerprint)
+
+### Register as a managed instance (if not EC2)
+
+```bash
+/etc/init.d/amazon-ssm-agent stop
+amazon-ssm-agent -register -code "<ACTIVATION_CODE>" -id "<ACTIVATION_ID>" -region "<REGION>"
+/etc/init.d/amazon-ssm-agent start
+```
+
+### Manage the service
+
+```bash
+/etc/init.d/amazon-ssm-agent start
+/etc/init.d/amazon-ssm-agent stop
+/etc/init.d/amazon-ssm-agent restart
+/etc/init.d/amazon-ssm-agent status
+```
+
+## Verification
+
+```bash
+# Check agent is running
+/etc/init.d/amazon-ssm-agent status
+
+# Check agent logs
+tail -f /var/log/amazon/ssm/amazon-ssm-agent.log
+
+# Check platform detection
+ssm-cli get-diagnostics
+```
+
+The agent should detect the platform as "Wind River Linux LTS" with version "10.22.33.16".
+
+## Yocto/BitBake Integration (Optional)
+
+If building WR Linux images via Yocto, create a recipe:
+
+```bitbake
+SUMMARY = "Amazon SSM Agent"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=..."
+
+SRC_URI = "file://amazon-ssm-agent-3.3.0.0.tar.gz"
+
+DEPENDS = "go-native"
+
+do_compile() {
+    export GOOS=linux
+    export GOARCH=amd64
+    export CGO_ENABLED=0
+    # Build commands from Option A above
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -d ${D}${sysconfdir}/amazon/ssm
+    install -d ${D}${localstatedir}/lib/amazon/ssm
+    install -d ${D}${systemd_system_unitdir}
+
+    install -m 0555 ${B}/bin/linux_amd64/amazon-ssm-agent ${D}${bindir}/
+    install -m 0555 ${B}/bin/linux_amd64/ssm-agent-worker ${D}${bindir}/
+    # ... remaining binaries ...
+
+    install -m 0644 ${S}/packaging/linux/amazon-ssm-agent.service \
+        ${D}${systemd_system_unitdir}/
+    install -m 0644 ${S}/amazon-ssm-agent.json.template \
+        ${D}${sysconfdir}/amazon/ssm/
+    install -m 0644 ${S}/seelog_unix.xml \
+        ${D}${sysconfdir}/amazon/ssm/seelog.xml.template
+}
+
+inherit update-rc.d
+INITSCRIPT_NAME = "amazon-ssm-agent"
+INITSCRIPT_PARAMS = "defaults"
+```
+
+## Known Limitations
+
+- **No systemd**: WR Linux LTS 22 on EC2 uses SysVinit (`/proc/1/comm` = `init`). A SysVinit init script is provided at `packaging/wrlinux/amazon-ssm-agent.init`. The systemd service file is **not used**.
+- **Self-update will fail**: The `Tools/src/update/linux/install.sh` script checks for upstart, then systemd. If neither is found it exits with code 124 ("unsupported platform"). This means the SSM Agent self-update mechanism will not work on WR Linux. **Manage updates manually** or patch `install.sh`/`uninstall.sh` to add a SysVinit code path.
+- **Self-update packages**: The updater downloads `linux_amd64` packages from AWS S3. These are Amazon-published RPMs built for standard Linux distributions. They *may* work on WR Linux if glibc is compatible, but this is not guaranteed.
+- **configurePackage plugin**: Mapped to `yum` package manager (rhel family). The target has `rpm` (4.17.1) but **not `yum`/`dnf`**. The `AWS-ConfigureAWSPackage` document may fail if it invokes `yum`. Direct `rpm` operations will work.
+- **Serial port startup**: Writes to `/dev/ttyS0` or `/dev/hvc0` on EC2. Non-fatal if serial port is unavailable.
+- **`/etc/machine-id`**: Used for instance fingerprinting. If not present (systemd normally creates this), create it manually: `dbus-uuidgen > /etc/machine-id` or check if `/var/lib/dbus/machine-id` exists instead (the agent checks both paths).

--- a/agent/plugins/configurepackage/envdetect/constants/constants.go
+++ b/agent/plugins/configurepackage/envdetect/constants/constants.go
@@ -82,6 +82,9 @@ const PlatformGentoo = "gentoo"
 // PlatformFlatcar uses Ohai identifier for flatcar platform
 const PlatformFlatcar = "flatcar"
 
+// PlatformWindRiver uses identifier for Wind River Linux platform
+const PlatformWindRiver = "wrlinux"
+
 // PlatformArch uses Ohai identifier for arch platform
 const PlatformArch = "arch"
 

--- a/agent/plugins/configurepackage/envdetect/osdetect/osdetect_unix.go
+++ b/agent/plugins/configurepackage/envdetect/osdetect/osdetect_unix.go
@@ -187,6 +187,8 @@ func parseOSreleaseFile(lines []string) (string, string, error) {
 		if strings.Contains(strings.ToLower(name), "leap") {
 			platform = c.PlatformOpensuseLeap
 		}
+	case "wrlinux":
+		platform = c.PlatformWindRiver
 	}
 
 	return platform, platformVersion, nil
@@ -420,6 +422,8 @@ func platformFamilyForPlatform(platform string) (string, error) {
 		return c.PlatformFamilyGentoo, nil
 	case c.PlatformArch:
 		return c.PlatformFamilyArch, nil
+	case c.PlatformWindRiver:
+		return c.PlatformFamilyRhel, nil
 	case c.PlatformBottlerocket, c.PlatformFlatcar:
 		return "", fmt.Errorf("configure package is not supported on %s", platform)
 	default:

--- a/agent/updateutil/updateconstants/constants.go
+++ b/agent/updateutil/updateconstants/constants.go
@@ -102,6 +102,9 @@ const (
 	// PlatformFlatcar represents Flatcar
 	PlatformFlatcar = "flatcar"
 
+	// PlatformWindRiver represents Wind River Linux
+	PlatformWindRiver = "wind river"
+
 	// PlatformSuse represents SLES(SUSe)
 	PlatformSuseOS = "sles"
 

--- a/agent/updateutil/updateinfo/updateinfo.go
+++ b/agent/updateutil/updateinfo/updateinfo.go
@@ -30,8 +30,9 @@ var isUsingSystemD map[string]string
 var updateInfoObj T
 
 var possiblyUsingSystemD = map[string]bool{
-	updateconstants.PlatformRaspbian: true,
-	updateconstants.PlatformLinux:    true,
+	updateconstants.PlatformRaspbian:  true,
+	updateconstants.PlatformLinux:     true,
+	updateconstants.PlatformWindRiver: true,
 }
 
 var execCommand = exec.Command
@@ -212,6 +213,10 @@ func newInner(context context.T) (updateInfo *updateInfoImpl, err error) {
 	} else if strings.Contains(platformName, updateconstants.PlatformFlatcar) {
 		log.Info("Detected platform Flatcar")
 		platformName = updateconstants.PlatformFlatcar
+		downloadPlatformOverride = updateconstants.PlatformLinux
+	} else if strings.Contains(platformName, updateconstants.PlatformWindRiver) {
+		log.Info("Detected platform Wind River Linux")
+		platformName = updateconstants.PlatformWindRiver
 		downloadPlatformOverride = updateconstants.PlatformLinux
 	} else if strings.Contains(platformName, updateconstants.PlatformSuseOS) {
 		log.Info("Detected platform SuseOS")

--- a/packaging/wrlinux/amazon-ssm-agent.init
+++ b/packaging/wrlinux/amazon-ssm-agent.init
@@ -1,0 +1,110 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          amazon-ssm-agent
+# Required-Start:    $network $remote_fs
+# Required-Stop:     $network $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Amazon SSM Agent
+# Description:       Amazon SSM Agent for managing EC2 and hybrid instances
+### END INIT INFO
+
+NAME=amazon-ssm-agent
+DAEMON=/usr/bin/amazon-ssm-agent
+PIDFILE=/var/run/${NAME}.pid
+LOGFILE=/var/log/amazon/ssm/${NAME}.log
+
+# Exit if the daemon binary is not installed
+[ -x "$DAEMON" ] || exit 5
+
+start() {
+    if is_running; then
+        echo "$NAME is already running (PID $(cat $PIDFILE))"
+        return 0
+    fi
+
+    echo "Starting $NAME..."
+    mkdir -p "$(dirname $LOGFILE)"
+    nohup $DAEMON >> "$LOGFILE" 2>&1 &
+    echo $! > "$PIDFILE"
+
+    sleep 1
+    if is_running; then
+        echo "$NAME started (PID $(cat $PIDFILE))"
+        return 0
+    else
+        echo "Failed to start $NAME"
+        rm -f "$PIDFILE"
+        return 1
+    fi
+}
+
+stop() {
+    if ! is_running; then
+        echo "$NAME is not running"
+        rm -f "$PIDFILE"
+        return 0
+    fi
+
+    echo "Stopping $NAME..."
+    kill "$(cat $PIDFILE)"
+
+    # Wait up to 10 seconds for graceful shutdown
+    i=0
+    while [ $i -lt 10 ]; do
+        if ! is_running; then
+            echo "$NAME stopped"
+            rm -f "$PIDFILE"
+            return 0
+        fi
+        sleep 1
+        i=$((i + 1))
+    done
+
+    # Force kill if still running
+    echo "Force killing $NAME..."
+    kill -9 "$(cat $PIDFILE)" 2>/dev/null
+    rm -f "$PIDFILE"
+    return 0
+}
+
+restart() {
+    stop
+    sleep 1
+    start
+}
+
+status() {
+    if is_running; then
+        echo "$NAME is running (PID $(cat $PIDFILE))"
+        return 0
+    else
+        echo "$NAME is not running"
+        return 3
+    fi
+}
+
+is_running() {
+    [ -f "$PIDFILE" ] && kill -0 "$(cat $PIDFILE)" 2>/dev/null
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart|force-reload)
+        restart
+        ;;
+    status)
+        status
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|force-reload|status}"
+        exit 2
+        ;;
+esac
+
+exit $?

--- a/packaging/wrlinux/amazon-ssm-agent.spec
+++ b/packaging/wrlinux/amazon-ssm-agent.spec
@@ -1,0 +1,105 @@
+%global debug_package %{nil}
+%define __requires_exclude_from .*
+AutoReq      : no
+AutoProv     : no
+
+Name         : amazon-ssm-agent
+Version      : %{_version}
+Release      : 1.wrlinux
+Summary      : Manage EC2 Instances using SSM APIs
+
+Group        : Amazon/Tools
+License      : ASL 2.0
+BuildRoot    : %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+URL          : http://docs.aws.amazon.com/ssm/latest/APIReference/Welcome.html
+
+Packager     : Amazon.com, Inc. <http://aws.amazon.com>
+Vendor       : Amazon.com
+
+# No BuildRequires — binaries are pre-built via cross-compilation
+# No ExcludeArch — targeting x86_64 explicitly
+
+%description
+This package provides Amazon SSM Agent for managing EC2 Instances using SSM APIs.
+Built for Wind River Linux LTS (SysVinit).
+
+%prep
+# Nothing to prepare — binaries are pre-built
+
+%build
+# Nothing to build — binaries are pre-built
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a %{_stagedir}/. %{buildroot}/
+
+%files
+%defattr(-,root,root,-)
+%{_prefix}/bin/amazon-ssm-agent
+%{_prefix}/bin/ssm-agent-worker
+%{_prefix}/bin/ssm-document-worker
+%{_prefix}/bin/ssm-session-worker
+%{_prefix}/bin/ssm-session-logger
+%{_prefix}/bin/ssm-cli
+%{_sysconfdir}/amazon/ssm/amazon-ssm-agent.json.template
+%{_sysconfdir}/amazon/ssm/seelog.xml.template
+%config(noreplace) %{_sysconfdir}/init.d/amazon-ssm-agent
+%{_localstatedir}/lib/amazon/ssm/
+%dir %{_localstatedir}/log/amazon/ssm/
+
+%doc
+%{_sysconfdir}/amazon/ssm/README.md
+%{_sysconfdir}/amazon/ssm/RELEASENOTES.md
+%{_sysconfdir}/amazon/ssm/NOTICE.md
+
+%post
+# First install
+if [ $1 -eq 1 ]; then
+    # Create machine-id if not present (needed for instance fingerprint)
+    if [ ! -f /etc/machine-id ] && [ ! -f /var/lib/dbus/machine-id ]; then
+        if command -v uuidgen >/dev/null 2>&1; then
+            uuidgen | tr -d '-' | tr '[:upper:]' '[:lower:]' > /etc/machine-id
+        fi
+    fi
+
+    # Enable service at boot via rc symlinks
+    if command -v update-rc.d >/dev/null 2>&1; then
+        update-rc.d amazon-ssm-agent defaults
+    elif command -v chkconfig >/dev/null 2>&1; then
+        chkconfig --add amazon-ssm-agent
+    else
+        # Manual symlinks as fallback
+        for rl in 3 5; do
+            ln -sf /etc/init.d/amazon-ssm-agent /etc/rc${rl}.d/S99amazon-ssm-agent 2>/dev/null || :
+        done
+        for rl in 0 1 6; do
+            ln -sf /etc/init.d/amazon-ssm-agent /etc/rc${rl}.d/K01amazon-ssm-agent 2>/dev/null || :
+        done
+    fi
+
+    # Start the agent
+    /etc/init.d/amazon-ssm-agent start || :
+fi
+
+# Upgrade
+if [ $1 -eq 2 ]; then
+    /etc/init.d/amazon-ssm-agent restart || :
+fi
+
+%preun
+# Only on uninstall (not upgrade)
+if [ $1 -eq 0 ]; then
+    /etc/init.d/amazon-ssm-agent stop >/dev/null 2>&1 || :
+
+    if command -v update-rc.d >/dev/null 2>&1; then
+        update-rc.d -f amazon-ssm-agent remove
+    elif command -v chkconfig >/dev/null 2>&1; then
+        chkconfig --del amazon-ssm-agent
+    else
+        rm -f /etc/rc*.d/*amazon-ssm-agent 2>/dev/null || :
+    fi
+fi
+
+%postun
+# Nothing extra needed for SysVinit

--- a/packaging/wrlinux/create_rpm.sh
+++ b/packaging/wrlinux/create_rpm.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -e
+
+# Build and package Amazon SSM Agent as RPM for Wind River Linux (SysVinit, x86_64)
+#
+# Usage:
+#   ./packaging/wrlinux/create_rpm.sh
+#
+# Prerequisites:
+#   - Go 1.24+ installed
+#   - rpmbuild installed (brew install rpm on macOS)
+#
+# Output:
+#   bin/linux_amd64/amazon-ssm-agent.rpm
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GO_SPACE="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+ARCH="amd64"
+TARGET="x86_64"
+FOLDER="linux_${ARCH}"
+VERSION=$(cat "${GO_SPACE}/VERSION")
+
+echo "============================================================"
+echo "Building Amazon SSM Agent ${VERSION} for Wind River Linux"
+echo "Architecture: ${TARGET} (${ARCH})"
+echo "============================================================"
+
+# ---------------------------------------------------------------
+# Step 1: Build binaries (cross-compile for linux/amd64)
+# ---------------------------------------------------------------
+echo ""
+echo "[1/3] Building Go binaries..."
+
+export GOOS=linux
+export GOARCH=${ARCH}
+export CGO_ENABLED=0
+
+OUTDIR="${GO_SPACE}/bin/${FOLDER}"
+mkdir -p "${OUTDIR}"
+
+GO_FLAGS="-ldflags -s -w -trimpath"
+
+cd "${GO_SPACE}"
+
+echo "  -> amazon-ssm-agent"
+CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath \
+  -o "${OUTDIR}/amazon-ssm-agent" \
+  core/agent.go core/agent_unix.go core/agent_parser.go
+
+echo "  -> ssm-agent-worker"
+CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath \
+  -o "${OUTDIR}/ssm-agent-worker" \
+  agent/agent.go agent/agent_unix.go agent/agent_parser.go
+
+echo "  -> ssm-document-worker"
+CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath \
+  -o "${OUTDIR}/ssm-document-worker" \
+  agent/framework/processor/executer/outofproc/worker/main.go
+
+echo "  -> ssm-session-worker"
+CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath \
+  -o "${OUTDIR}/ssm-session-worker" \
+  agent/framework/processor/executer/outofproc/sessionworker/main.go
+
+echo "  -> ssm-session-logger"
+CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath \
+  -o "${OUTDIR}/ssm-session-logger" \
+  agent/session/logging/main.go
+
+echo "  -> ssm-cli"
+CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath \
+  -o "${OUTDIR}/ssm-cli" \
+  agent/cli-main/cli-main.go
+
+echo "  -> updater"
+CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath \
+  -o "${OUTDIR}/updater" \
+  agent/update/updater/updater.go agent/update/updater/updater_unix.go
+
+echo "  -> ssm-setup-cli"
+CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath \
+  -o "${OUTDIR}/ssm-setup-cli" \
+  agent/setupcli/setupcli.go
+
+echo "  Binaries built in ${OUTDIR}/"
+
+# ---------------------------------------------------------------
+# Step 2: Prepare rpmbuild workspace
+# ---------------------------------------------------------------
+echo ""
+echo "[2/3] Preparing RPM build workspace..."
+
+STAGEDIR="${GO_SPACE}/bin/${FOLDER}/staging"
+RPM_TOPDIR="${GO_SPACE}/bin/${FOLDER}/rpmbuild"
+
+rm -rf "${STAGEDIR}" "${RPM_TOPDIR}"
+
+mkdir -p "${RPM_TOPDIR}"/{SPECS,SOURCES,BUILD,RPMS,SRPMS}
+mkdir -p "${STAGEDIR}/usr/bin"
+mkdir -p "${STAGEDIR}/etc/amazon/ssm"
+mkdir -p "${STAGEDIR}/etc/init.d"
+mkdir -p "${STAGEDIR}/var/lib/amazon/ssm"
+mkdir -p "${STAGEDIR}/var/log/amazon/ssm"
+
+# Copy binaries
+cp "${OUTDIR}/amazon-ssm-agent"     "${STAGEDIR}/usr/bin/"
+cp "${OUTDIR}/ssm-agent-worker"      "${STAGEDIR}/usr/bin/"
+cp "${OUTDIR}/ssm-document-worker"   "${STAGEDIR}/usr/bin/"
+cp "${OUTDIR}/ssm-session-worker"    "${STAGEDIR}/usr/bin/"
+cp "${OUTDIR}/ssm-session-logger"    "${STAGEDIR}/usr/bin/"
+cp "${OUTDIR}/ssm-cli"              "${STAGEDIR}/usr/bin/"
+
+# Copy config files
+cp "${GO_SPACE}/amazon-ssm-agent.json.template" "${STAGEDIR}/etc/amazon/ssm/"
+cp "${GO_SPACE}/seelog_unix.xml"                 "${STAGEDIR}/etc/amazon/ssm/seelog.xml.template"
+cp "${GO_SPACE}/README.md"                       "${STAGEDIR}/etc/amazon/ssm/"
+cp "${GO_SPACE}/RELEASENOTES.md"                 "${STAGEDIR}/etc/amazon/ssm/"
+cp "${GO_SPACE}/NOTICE.md"                       "${STAGEDIR}/etc/amazon/ssm/"
+
+# Copy SysVinit init script
+cp "${SCRIPT_DIR}/amazon-ssm-agent.init"         "${STAGEDIR}/etc/init.d/amazon-ssm-agent"
+chmod 755 "${STAGEDIR}/etc/init.d/amazon-ssm-agent"
+
+# ---------------------------------------------------------------
+# Step 3: Build RPM
+# ---------------------------------------------------------------
+echo ""
+echo "[3/3] Building RPM package..."
+
+SPEC_FILE="${SCRIPT_DIR}/amazon-ssm-agent.spec"
+
+# Create minimal fileattrs dir to suppress macOS rpmbuild file classification errors
+EMPTY_FILEATTRS="${RPM_TOPDIR}/fileattrs"
+mkdir -p "${EMPTY_FILEATTRS}"
+echo '%__none_provides %{nil}' > "${EMPTY_FILEATTRS}/none.attr"
+
+rpmbuild -bb \
+  --target "${TARGET}-linux" \
+  --define "_version ${VERSION}" \
+  --define "_topdir ${RPM_TOPDIR}" \
+  --define "_stagedir ${STAGEDIR}" \
+  --define "_prefix /usr" \
+  --define "_sysconfdir /etc" \
+  --define "_localstatedir /var" \
+  --define "_tmppath /tmp" \
+  --define "_fileattrsdir ${EMPTY_FILEATTRS}" \
+  "${SPEC_FILE}"
+
+# Copy RPM to output directory
+RPM_FILE=$(find "${RPM_TOPDIR}/RPMS/${TARGET}/" -name "*.rpm" -type f | head -1)
+
+if [ -z "${RPM_FILE}" ]; then
+  echo "ERROR: RPM file not found!"
+  exit 1
+fi
+
+cp "${RPM_FILE}" "${OUTDIR}/amazon-ssm-agent-${VERSION}.wrlinux.${TARGET}.rpm"
+
+echo ""
+echo "============================================================"
+echo "SUCCESS!"
+echo ""
+echo "RPM: ${OUTDIR}/amazon-ssm-agent-${VERSION}.wrlinux.${TARGET}.rpm"
+echo ""
+echo "Install on Wind River Linux:"
+echo "  scp ${OUTDIR}/amazon-ssm-agent-${VERSION}.wrlinux.${TARGET}.rpm root@<host>:/tmp/"
+echo "  ssh root@<host> rpm -i /tmp/amazon-ssm-agent-${VERSION}.wrlinux.${TARGET}.rpm"
+echo ""
+echo "The RPM will automatically:"
+echo "  - Install binaries to /usr/bin/"
+echo "  - Install config to /etc/amazon/ssm/"
+echo "  - Install SysVinit init script to /etc/init.d/"
+echo "  - Create /var/lib/amazon/ssm/ and /var/log/amazon/ssm/"
+echo "  - Enable and start the agent"
+echo "============================================================"


### PR DESCRIPTION
Platform detection:
- Add PlatformWindRiver constant ("wrlinux") for configurepackage
- Map wrlinux OS-release ID to PlatformWindRiver in osdetect
- Map PlatformWindRiver to rhel family (RPM-based)
- Add PlatformWindRiver constant ("wind river") for updater
- Add Wind River to possiblyUsingSystemD map
- Add platform detection chain entry with linux download override

RPM packaging for SysVinit:
- Add RPM spec file for Wind River Linux (SysVinit, no systemd)
- Add SysVinit init script with start/stop/restart/status
- Add create_rpm.sh build script (cross-compile + rpmbuild)
- Add BUILD_WRLINUX.md with complete build instructions

Tested on Wind River Linux LTS 10.22.33.16 (amd64) EC2 instance. Agent starts, registers with SSM, and survives reboots.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
