### PR TITLE
Optimize build commands in amazon-ssm-agent.spec

### DIFF
--- a/amazon-ssm-agent.spec
+++ b/amazon-ssm-agent.spec
@@ -34,12 +34,12 @@ sed -i -e 's#const[ \s]*Version.*#const Version = "%{version}"#g' agent/version/
 
 %build
 
-CGO_ENABLED=0 go build -ldflags "-extldflags=-Wl,-z,now,-z,relro,-z,defs -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -buildmode=pie -o bin/amazon-ssm-agent -v core/agent.go core/agent_unix.go core/agent_parser.go
-CGO_ENABLED=0 go build -ldflags "-extldflags=-Wl,-z,now,-z,relro,-z,defs -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -buildmode=pie -o bin/ssm-agent-worker -v agent/agent.go agent/agent_unix.go agent/agent_parser.go
-CGO_ENABLED=0 go build -ldflags "-extldflags=-Wl,-z,now,-z,relro,-z,defs -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -buildmode=pie -o bin/ssm-document-worker -v agent/framework/processor/executer/outofproc/worker/main.go
-CGO_ENABLED=0 go build -ldflags "-extldflags=-Wl,-z,now,-z,relro,-z,defs -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -buildmode=pie -o bin/ssm-session-worker -v agent/framework/processor/executer/outofproc/sessionworker/main.go
-CGO_ENABLED=0 go build -ldflags "-extldflags=-Wl,-z,now,-z,relro,-z,defs -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -buildmode=pie -o bin/ssm-session-logger -v agent/session/logging/main.go
-CGO_ENABLED=0 go build -ldflags "-extldflags=-Wl,-z,now,-z,relro,-z,defs -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -buildmode=pie -o bin/ssm-cli -v agent/cli-main/cli-main.go
+CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -extldflags=-Wl,-z,now,-z,relro,-z,defs -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -buildmode=pie -o bin/amazon-ssm-agent -v core/agent.go core/agent_unix.go core/agent_parser.go
+CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -extldflags=-Wl,-z,now,-z,relro,-z,defs -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -buildmode=pie -o bin/ssm-agent-worker -v agent/agent.go agent/agent_unix.go agent/agent_parser.go
+CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -extldflags=-Wl,-z,now,-z,relro,-z,defs -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -buildmode=pie -o bin/ssm-document-worker -v agent/framework/processor/executer/outofproc/worker/main.go
+CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -extldflags=-Wl,-z,now,-z,relro,-z,defs -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -buildmode=pie -o bin/ssm-session-worker -v agent/framework/processor/executer/outofproc/sessionworker/main.go
+CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -extldflags=-Wl,-z,now,-z,relro,-z,defs -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -buildmode=pie -o bin/ssm-session-logger -v agent/session/logging/main.go
+CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -extldflags=-Wl,-z,now,-z,relro,-z,defs -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -buildmode=pie -o bin/ssm-cli -v agent/cli-main/cli-main.go
 
 %install
 


### PR DESCRIPTION

*Issue #, if available:*
rpm does not get fully stripped

*Description of changes:*
Updated build commands to include -trimpath and -s -w flags for optimization (like in makefile). Reduces binary size by ~6MB


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
